### PR TITLE
Implement pre-rendering of frames

### DIFF
--- a/src/audio/AudioClient.java
+++ b/src/audio/AudioClient.java
@@ -19,7 +19,6 @@ public class AudioClient {
     //  Reduce weight of lines drawn multiple times.
     //  Find intersections of lines to (possibly) improve line cleanup.
     //  Improve performance of line cleanup with a heuristic.
-    //  Pre-render in parallel.
 
     Camera camera = new Camera(0.6, new Vector3(0, 0, -0.08));
     WorldObject object = new WorldObject(args[0], new Vector3(0, 0, 0), new Vector3());

--- a/src/audio/AudioClient.java
+++ b/src/audio/AudioClient.java
@@ -3,30 +3,40 @@ package audio;
 import engine.Camera;
 import engine.Vector3;
 import engine.WorldObject;
+import java.util.ArrayList;
+import java.util.List;
+import shapes.Shape;
 import shapes.Shapes;
+import shapes.Vector2;
 
 public class AudioClient {
-  private static final int SAMPLE_RATE = 192000;
-  private static final double TARGET_FRAMERATE = 30;
+  public static final int SAMPLE_RATE = 192000;
+  public static final double TARGET_FRAMERATE = 30;
 
-  public static void main(String[] args) throws InterruptedException {
+  public static void main(String[] args) {
     // TODO: Calculate weight of lines using depth.
     //  Reduce weight of lines drawn multiple times.
     //  Find intersections of lines to (possibly) improve line cleanup.
     //  Improve performance of line cleanup with a heuristic.
+    //  Pre-render in parallel.
 
-    AudioPlayer player = new AudioPlayer(SAMPLE_RATE, 440);
-
-    Camera camera = new Camera(0.6, new Vector3(0, 0, -3));
-    WorldObject cube = new WorldObject(args[0], new Vector3(0, 0, 0), new Vector3());
+    Camera camera = new Camera(0.8, new Vector3(0, 0, -3));
+    WorldObject object = new WorldObject(args[0], new Vector3(0, 0, 0), new Vector3());
     Vector3 rotation = new Vector3(0,Math.PI / 100,Math.PI / 100);
+    List<List<? extends Shape>> preRenderedFrames = new ArrayList<>();
 
-    player.start();
+    int numFrames = (int) (Float.parseFloat(args[1]) * TARGET_FRAMERATE);
 
-    while (true) {
-      AudioPlayer.updateFrame(Shapes.sortLines(camera.draw(cube)));
-      cube.rotate(rotation);
-      Thread.sleep((long) (1000 / TARGET_FRAMERATE));
+
+
+    for (int i = 0; i < numFrames; i++) {
+      preRenderedFrames.add(Shapes.sortLines(camera.draw(object)));
+      object.rotate(rotation);
     }
+
+    AudioPlayer player = new AudioPlayer(SAMPLE_RATE, preRenderedFrames);
+    //AudioPlayer.setRotateSpeed(1);
+    //AudioPlayer.setTranslation(1, new Vector2(1, 1));
+    player.start();
   }
 }

--- a/src/audio/AudioClient.java
+++ b/src/audio/AudioClient.java
@@ -5,6 +5,7 @@ import engine.Vector3;
 import engine.WorldObject;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.IntStream;
 import shapes.Shape;
 import shapes.Shapes;
 import shapes.Vector2;
@@ -20,19 +21,26 @@ public class AudioClient {
     //  Improve performance of line cleanup with a heuristic.
     //  Pre-render in parallel.
 
-    Camera camera = new Camera(0.8, new Vector3(0, 0, -3));
+    Camera camera = new Camera(0.6, new Vector3(0, 0, -0.08));
     WorldObject object = new WorldObject(args[0], new Vector3(0, 0, 0), new Vector3());
     Vector3 rotation = new Vector3(0,Math.PI / 100,Math.PI / 100);
     List<List<? extends Shape>> preRenderedFrames = new ArrayList<>();
 
     int numFrames = (int) (Float.parseFloat(args[1]) * TARGET_FRAMERATE);
 
-
+    long start = System.currentTimeMillis();
 
     for (int i = 0; i < numFrames; i++) {
-      preRenderedFrames.add(Shapes.sortLines(camera.draw(object)));
-      object.rotate(rotation);
+      preRenderedFrames.add(new ArrayList<>());
     }
+
+    IntStream.range(0, numFrames).parallel().forEach((frameNum) -> {
+      WorldObject clone = object.clone();
+      clone.rotate(rotation.scale(frameNum));
+      preRenderedFrames.set(frameNum, Shapes.sortLines(camera.draw(clone)));
+    });
+
+    System.out.println(System.currentTimeMillis() - start);
 
     AudioPlayer player = new AudioPlayer(SAMPLE_RATE, preRenderedFrames);
     //AudioPlayer.setRotateSpeed(1);

--- a/src/audio/AudioPlayer.java
+++ b/src/audio/AudioPlayer.java
@@ -136,7 +136,7 @@ public class AudioPlayer extends Thread {
   }
 
   private static Shape getCurrentShape() {
-    if (frames.size() == 0) {
+    if (frames.size() == 0 || frames.get(currentFrame).size() == 0) {
       return new Vector2(0, 0);
     }
 

--- a/src/engine/Vector3.java
+++ b/src/engine/Vector3.java
@@ -84,4 +84,8 @@ public final class Vector3 {
 
     return mean.scale(1f / (points.size()));
   }
+
+  public Vector3 clone() {
+    return new Vector3(x, y, z);
+  }
 }

--- a/src/engine/WorldObject.java
+++ b/src/engine/WorldObject.java
@@ -23,8 +23,19 @@ public class WorldObject {
     loadFromFile(filename);
   }
 
+  public WorldObject(List<Vector3> vertices, List<Integer> edgeData, Vector3 position, Vector3 rotation) {
+    this.vertices = vertices;
+    this.edgeData = edgeData;
+    this.position = position;
+    this.rotation = rotation;
+  }
+
   public void rotate(Vector3 theta) {
     rotation = rotation.add(theta);
+  }
+
+  public void resetRotation() {
+    rotation = new Vector3();
   }
 
   public List<Vector3> getVertices() {
@@ -66,5 +77,21 @@ public class WorldObject {
       e.printStackTrace();
       throw new IllegalArgumentException("Cannot load mesh data from: " + filename);
     }
+  }
+
+  public WorldObject clone() {
+    List<Vector3> newVertices = new ArrayList<>();
+
+    for (Vector3 vertex : vertices) {
+      newVertices.add(vertex.clone());
+    }
+
+    List<Integer> newEdgeData = new ArrayList<>();
+
+    for (int edge : edgeData) {
+      newEdgeData.add(edge);
+    }
+
+    return new WorldObject(newVertices, newEdgeData, position.clone(), rotation.clone());
   }
 }

--- a/src/shapes/Shapes.java
+++ b/src/shapes/Shapes.java
@@ -65,7 +65,7 @@ public class Shapes {
       .orElse(0d);
   }
 
-  public static List<Line> sortLines(List<Line> lines) {
+  public static List<Shape> sortLines(List<Line> lines) {
     Graph<Vector2, DefaultWeightedEdge> graph = new DefaultUndirectedWeightedGraph<>(DefaultWeightedEdge.class);
 
     for (Line line : lines) {
@@ -79,7 +79,7 @@ public class Shapes {
 
     ConnectivityInspector<Vector2, DefaultWeightedEdge> inspector = new ConnectivityInspector<>(graph);
 
-    List<Line> sortedLines = new ArrayList<>();
+    List<Shape> sortedLines = new ArrayList<>();
 
     for (Set<Vector2> vertices : inspector.connectedSets()) {
       AsSubgraph<Vector2, DefaultWeightedEdge> subgraph = new AsSubgraph<>(graph, vertices);


### PR DESCRIPTION
When the program runs it will now hang and pre-render the frames to be drawn on the screen. This helps improve performance when rendering complicated models and reduces the load on the computer if the same animation is rendered for a long amount of time.

TODO: Add verbose messages for pre-rendering progress.