### PR TITLE
Implement image auto-scaling

### DIFF
--- a/src/audio/AudioArgs.java
+++ b/src/audio/AudioArgs.java
@@ -1,0 +1,59 @@
+package audio;
+
+// Helper class for AudioClient that deals with optional program arguments.
+final class AudioArgs {
+
+  final String objFilePath;
+  final float[] optionalArgs;
+
+  AudioArgs(String[] args) throws IllegalAudioArgumentException {
+    if (args.length < 1 || args.length > 6) {
+      throw new IllegalAudioArgumentException();
+    }
+
+    objFilePath = args[0];
+    optionalArgs = new float[args.length - 1];
+
+    for (int i = 0; i < optionalArgs.length; i++) {
+      optionalArgs[i] = Float.parseFloat(args[i + 1]);
+    }
+  }
+
+  String objFilePath() {
+    return objFilePath;
+  }
+
+  float rotateSpeed() {
+    return getArg(0, 0);
+  }
+
+  float cameraX() {
+    return getArg(1, 0);
+  }
+
+  float cameraY() {
+    return getArg(2, 0);
+  }
+
+  float cameraZ() {
+    return getArg(3, 0);
+  }
+
+  float focalLength() {
+    return getArg(4, 1);
+  }
+
+  private float getArg(int n, float defaultVal) {
+    return optionalArgs.length > n ? optionalArgs[n] : defaultVal;
+  }
+
+  private class IllegalAudioArgumentException extends IllegalArgumentException {
+
+    private static final String USAGE = "Incorrect usage.\nUsage: osci-render objFilePath "
+        + "[rotateSpeed] [cameraX] [cameraY] [cameraZ] [focalLength]";
+
+    public IllegalAudioArgumentException() {
+      super(USAGE);
+    }
+  }
+}

--- a/src/audio/AudioArgs.java
+++ b/src/audio/AudioArgs.java
@@ -1,5 +1,7 @@
 package audio;
 
+import engine.Camera;
+
 // Helper class for AudioClient that deals with optional program arguments.
 final class AudioArgs {
 
@@ -40,7 +42,7 @@ final class AudioArgs {
   }
 
   float focalLength() {
-    return getArg(4, 1);
+    return getArg(4, (float) Camera.DEFAULT_FOCAL_LENGTH);
   }
 
   private float getArg(int n, float defaultVal) {

--- a/src/audio/AudioArgs.java
+++ b/src/audio/AudioArgs.java
@@ -29,20 +29,24 @@ final class AudioArgs {
     return getArg(0, 0);
   }
 
-  float cameraX() {
-    return getArg(1, 0);
+  float focalLength() {
+    return getArg(1, (float) Camera.DEFAULT_FOCAL_LENGTH);
   }
 
-  float cameraY() {
+  float cameraX() {
     return getArg(2, 0);
   }
 
-  float cameraZ() {
+  float cameraY() {
     return getArg(3, 0);
   }
 
-  float focalLength() {
-    return getArg(4, (float) Camera.DEFAULT_FOCAL_LENGTH);
+  float cameraZ() {
+    return getArg(4, 0);
+  }
+
+  boolean isDefaultPosition() {
+    return optionalArgs.length <= 2;
   }
 
   private float getArg(int n, float defaultVal) {

--- a/src/audio/AudioClient.java
+++ b/src/audio/AudioClient.java
@@ -12,6 +12,7 @@ import shapes.Shapes;
 import shapes.Vector2;
 
 public class AudioClient {
+
   private static final int SAMPLE_RATE = 192000;
   private static double OBJ_ROTATE_SPEED = Math.PI / 1000;
   private static final float ROTATE_SPEED = 0;
@@ -30,32 +31,38 @@ public class AudioClient {
   //
   // example:
   // osci-render models/cube.obj 1 0 0 -3 10
-  public static void main(String[] args) {
+  public static void main(String[] programArgs) {
     // TODO: Calculate weight of lines using depth.
     //  Reduce weight of lines drawn multiple times.
     //  Find intersections of lines to (possibly) improve line cleanup.
     //  Improve performance of line cleanup with a heuristic.
 
-    String objFilePath = args[0];
-    float focalLength = Float.parseFloat(args[1]);
-    float cameraX = Float.parseFloat(args[2]);
-    float cameraY = Float.parseFloat(args[3]);
-    float cameraZ = Float.parseFloat(args[4]);
+    AudioArgs args = new AudioArgs(programArgs);
 
-    OBJ_ROTATE_SPEED *= Double.parseDouble(args[5]);
+    OBJ_ROTATE_SPEED *= args.rotateSpeed();
 
-    int numFrames = (int) (2 * Math.PI / OBJ_ROTATE_SPEED);
-
-    Camera camera = new Camera(focalLength, new Vector3(cameraX, cameraY, cameraZ));
-    WorldObject object = new WorldObject(objFilePath);
+    Vector3 cameraPos = new Vector3(args.cameraX(), args.cameraY(), args.cameraZ());
+    Camera camera = new Camera(args.focalLength(), cameraPos);
+    WorldObject object = new WorldObject(args.objFilePath());
     Vector3 rotation = new Vector3(0, OBJ_ROTATE_SPEED, OBJ_ROTATE_SPEED);
+
+    System.out.println("Begin pre-render...");
+    List<List<? extends Shape>> frames = preRender(object, rotation, camera);
+    System.out.println("Finish pre-render");
+    System.out.println("Connecting to audio player");
+    AudioPlayer player = new AudioPlayer(SAMPLE_RATE, frames, ROTATE_SPEED, TRANSLATION_SPEED, TRANSLATION, SCALE, WEIGHT);
+    System.out.println("Starting audio stream");
+    player.play();
+  }
+
+  private static List<List<? extends Shape>> preRender(WorldObject object, Vector3 rotation, Camera camera) {
     List<List<? extends Shape>> preRenderedFrames = new ArrayList<>();
+    int numFrames = (int) (2 * Math.PI / OBJ_ROTATE_SPEED);
 
     for (int i = 0; i < numFrames; i++) {
       preRenderedFrames.add(new ArrayList<>());
     }
 
-    System.out.println("Begin pre-render...");
     AtomicInteger renderedFrames = new AtomicInteger();
 
     // pre-renders the WorldObject in parallel
@@ -70,16 +77,6 @@ public class AudioClient {
       }
     });
 
-    System.out.println("Finish pre-render");
-
-    System.out.println("Connecting to audio player");
-    AudioPlayer player = new AudioPlayer(SAMPLE_RATE, preRenderedFrames);
-    player.setRotateSpeed(ROTATE_SPEED);
-    player.setTranslation(TRANSLATION_SPEED, TRANSLATION);
-    player.setScale(SCALE);
-    player.setWeight(WEIGHT);
-
-    System.out.println("Starting audio stream");
-    player.start();
+    return preRenderedFrames;
   }
 }

--- a/src/audio/AudioClient.java
+++ b/src/audio/AudioClient.java
@@ -50,12 +50,14 @@ public class AudioClient {
     List<List<? extends Shape>> frames = preRender(object, rotation, camera);
     System.out.println("Finish pre-render");
     System.out.println("Connecting to audio player");
-    AudioPlayer player = new AudioPlayer(SAMPLE_RATE, frames, ROTATE_SPEED, TRANSLATION_SPEED, TRANSLATION, SCALE, WEIGHT);
+    AudioPlayer player = new AudioPlayer(SAMPLE_RATE, frames, ROTATE_SPEED, TRANSLATION_SPEED,
+        TRANSLATION, SCALE, WEIGHT);
     System.out.println("Starting audio stream");
     player.play();
   }
 
-  private static List<List<? extends Shape>> preRender(WorldObject object, Vector3 rotation, Camera camera) {
+  private static List<List<? extends Shape>> preRender(WorldObject object, Vector3 rotation,
+      Camera camera) {
     List<List<? extends Shape>> preRenderedFrames = new ArrayList<>();
     int numFrames = (int) (2 * Math.PI / OBJ_ROTATE_SPEED);
 

--- a/src/audio/AudioPlayer.java
+++ b/src/audio/AudioPlayer.java
@@ -20,7 +20,7 @@ public class AudioPlayer {
   private double rotateSpeed = 0;
   private final Phase rotatePhase = new Phase();
   private double scale = 1;
-  private double weight = 100;
+  private double weight = Shape.DEFAULT_WEIGHT;
 
   private volatile boolean stopped;
 

--- a/src/audio/AudioPlayer.java
+++ b/src/audio/AudioPlayer.java
@@ -15,6 +15,7 @@ import shapes.Vector2;
 import java.util.List;
 
 public class AudioPlayer {
+
   private final XtFormat FORMAT;
 
   private final List<List<? extends Shape>> frames;
@@ -37,7 +38,8 @@ public class AudioPlayer {
     this.frames = frames;
   }
 
-  public AudioPlayer(int sampleRate, List<List<? extends Shape>> frames, float rotateSpeed, float translateSpeed, Vector2 translateVector, float scale, float weight) {
+  public AudioPlayer(int sampleRate, List<List<? extends Shape>> frames, float rotateSpeed,
+      float translateSpeed, Vector2 translateVector, float scale, float weight) {
     this(sampleRate, frames);
     setRotateSpeed(rotateSpeed);
     setTranslation(translateSpeed, translateVector);
@@ -46,7 +48,7 @@ public class AudioPlayer {
   }
 
   private void render(XtStream stream, Object input, Object output, int audioFrames,
-                     double time, long position, boolean timeValid, long error, Object user) {
+      double time, long position, boolean timeValid, long error, Object user) {
     for (int f = 0; f < audioFrames; f++) {
       Shape shape = getCurrentShape();
 
@@ -80,7 +82,7 @@ public class AudioPlayer {
   private Shape rotate(Shape shape, double sampleRate) {
     if (rotateSpeed != 0) {
       shape = shape.rotate(
-        nextTheta(sampleRate, rotateSpeed, translatePhase)
+          nextTheta(sampleRate, rotateSpeed, translatePhase)
       );
     }
 
@@ -90,7 +92,7 @@ public class AudioPlayer {
   private Shape translate(Shape shape, double sampleRate) {
     if (translateSpeed != 0 && !translateVector.equals(new Vector2())) {
       return shape.translate(translateVector.scale(
-        Math.sin(nextTheta(sampleRate, translateSpeed, rotatePhase))
+          Math.sin(nextTheta(sampleRate, translateSpeed, rotatePhase))
       ));
     }
 
@@ -148,7 +150,7 @@ public class AudioPlayer {
           XtBuffer buffer = device.getBuffer(FORMAT);
 
           try (XtStream stream = device.openStream(FORMAT, true, false,
-            buffer.current, this::render, null, null)) {
+              buffer.current, this::render, null, null)) {
             stream.start();
             while (!stopped) {
               Thread.onSpinWait();
@@ -165,6 +167,7 @@ public class AudioPlayer {
   }
 
   private static final class Phase {
+
     private double value = 0;
   }
 }

--- a/src/audio/AudioPlayer.java
+++ b/src/audio/AudioPlayer.java
@@ -1,14 +1,12 @@
 package audio;
 
 import com.xtaudio.xt.*;
-import java.time.Duration;
-import java.time.Instant;
 import shapes.Shape;
 import shapes.Vector2;
 
 import java.util.List;
 
-public class AudioPlayer extends Thread {
+public class AudioPlayer {
   private final XtFormat FORMAT;
 
   private final List<List<? extends Shape>> frames;
@@ -29,6 +27,14 @@ public class AudioPlayer extends Thread {
   public AudioPlayer(int sampleRate, List<List<? extends Shape>> frames) {
     this.FORMAT = new XtFormat(new XtMix(sampleRate, XtSample.FLOAT32), 0, 0, 2, 0);
     this.frames = frames;
+  }
+
+  public AudioPlayer(int sampleRate, List<List<? extends Shape>> frames, float rotateSpeed, float translateSpeed, Vector2 translateVector, float scale, float weight) {
+    this(sampleRate, frames);
+    setRotateSpeed(rotateSpeed);
+    setTranslation(translateSpeed, translateVector);
+    setScale(scale);
+    setWeight(weight);
   }
 
   private void render(XtStream stream, Object input, Object output, int audioFrames,
@@ -126,14 +132,13 @@ public class AudioPlayer extends Thread {
     return frames.get(currentFrame).get(currentShape);
   }
 
-  @Override
-  public void run() {
+  public void play() {
     try (XtAudio audio = new XtAudio(null, null, null, null)) {
       XtService service = XtAudio.getServiceBySetup(XtSetup.CONSUMER_AUDIO);
       try (XtDevice device = service.openDefaultDevice(true)) {
         if (device != null && device.supportsFormat(FORMAT)) {
-
           XtBuffer buffer = device.getBuffer(FORMAT);
+
           try (XtStream stream = device.openStream(FORMAT, true, false,
             buffer.current, this::render, null, null)) {
             stream.start();

--- a/src/audio/AudioPlayer.java
+++ b/src/audio/AudioPlayer.java
@@ -1,6 +1,14 @@
 package audio;
 
-import com.xtaudio.xt.*;
+import com.xtaudio.xt.XtAudio;
+import com.xtaudio.xt.XtBuffer;
+import com.xtaudio.xt.XtDevice;
+import com.xtaudio.xt.XtFormat;
+import com.xtaudio.xt.XtMix;
+import com.xtaudio.xt.XtSample;
+import com.xtaudio.xt.XtService;
+import com.xtaudio.xt.XtSetup;
+import com.xtaudio.xt.XtStream;
 import shapes.Shape;
 import shapes.Vector2;
 

--- a/src/engine/Camera.java
+++ b/src/engine/Camera.java
@@ -8,6 +8,8 @@ import java.util.List;
 
 public class Camera {
 
+  public static double DEFAULT_FOCAL_LENGTH = 1;
+
   private double focalLength;
   private double clipping = 0.001;
   private Vector3 pos;
@@ -15,6 +17,18 @@ public class Camera {
   public Camera(double focalLength, Vector3 pos) {
     this.focalLength = focalLength;
     this.pos = pos;
+  }
+
+  public Camera(double focalLength) {
+    this(focalLength, new Vector3());
+  }
+
+  public Camera(Vector3 pos) {
+    this(DEFAULT_FOCAL_LENGTH, pos);
+  }
+
+  public Camera() {
+    this(DEFAULT_FOCAL_LENGTH, new Vector3());
   }
 
   public List<Line> draw(WorldObject worldObject) {
@@ -31,9 +45,21 @@ public class Camera {
     return vertices;
   }
 
+  public Vector3 getPos() {
+    return pos.clone();
+  }
+
+  public void setPos(Vector3 pos) {
+    this.pos = pos;
+  }
+
+  public void move(Vector3 dir) {
+    pos = pos.add(dir);
+  }
+
   private Vector2 project(Vector3 vertex) {
     if (vertex.getZ() - pos.getZ() < clipping) {
-      return new Vector2(0, 0);
+      return new Vector2();
     }
 
     return new Vector2(

--- a/src/engine/Camera.java
+++ b/src/engine/Camera.java
@@ -7,6 +7,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class Camera {
+
   private double focalLength;
   private double clipping = 0.001;
   private Vector3 pos;
@@ -17,23 +18,27 @@ public class Camera {
   }
 
   public List<Line> draw(WorldObject worldObject) {
+    return getFrame(getProjectedVertices(worldObject), worldObject.getEdgeData());
+  }
+
+  public List<Vector2> getProjectedVertices(WorldObject worldObject) {
     List<Vector2> vertices = new ArrayList<>();
 
-    for(Vector3 vertex : worldObject.getVertices()) {
+    for (Vector3 vertex : worldObject.getVertices()) {
       vertices.add(project(vertex));
     }
 
-    return getFrame(vertices, worldObject.getEdgeData());
+    return vertices;
   }
 
   private Vector2 project(Vector3 vertex) {
-    if(vertex.getZ() - pos.getZ() < clipping) {
+    if (vertex.getZ() - pos.getZ() < clipping) {
       return new Vector2(0, 0);
     }
 
     return new Vector2(
-      vertex.getX() * focalLength / (vertex.getZ() - pos.getZ()) + pos.getX(),
-      vertex.getY() * focalLength / (vertex.getZ() - pos.getZ()) + pos.getY()
+        vertex.getX() * focalLength / (vertex.getZ() - pos.getZ()) + pos.getX(),
+        vertex.getY() * focalLength / (vertex.getZ() - pos.getZ()) + pos.getY()
     );
   }
 

--- a/src/engine/Vector3.java
+++ b/src/engine/Vector3.java
@@ -3,6 +3,7 @@ package engine;
 import java.util.List;
 
 public final class Vector3 {
+
   private final double x, y, z;
 
   public Vector3() {
@@ -31,47 +32,47 @@ public final class Vector3 {
 
   public Vector3 add(Vector3 other) {
     return new Vector3(
-      getX() + other.getX(),
-      getY() + other.getY(),
-      getZ() + other.getZ()
+        getX() + other.getX(),
+        getY() + other.getY(),
+        getZ() + other.getZ()
     );
   }
 
   public Vector3 scale(double factor) {
     return new Vector3(
-      getX() * factor,
-      getY() * factor,
-      getZ() * factor
+        getX() * factor,
+        getY() * factor,
+        getZ() * factor
     );
   }
 
   public Vector3 rotate(Vector3 rotation) {
     return rotateX(rotation.getX())
-      .rotateY(rotation.getY())
-      .rotateZ(rotation.getZ());
+        .rotateY(rotation.getY())
+        .rotateZ(rotation.getZ());
   }
 
   public Vector3 rotateX(double theta) {
     return new Vector3(
-      getX(),
-      Math.cos(theta) * getY() - Math.sin(theta) * getZ(),
-      Math.sin(theta) * getY() + Math.cos(theta) * getZ()
+        getX(),
+        Math.cos(theta) * getY() - Math.sin(theta) * getZ(),
+        Math.sin(theta) * getY() + Math.cos(theta) * getZ()
     );
   }
 
   public Vector3 rotateY(double theta) {
     return new Vector3(
-      Math.cos(theta) * getX() + Math.sin(theta) * getZ(),
-      getY(),
-      -Math.sin(theta) * getX() + Math.cos(theta) * getZ()
+        Math.cos(theta) * getX() + Math.sin(theta) * getZ(),
+        getY(),
+        -Math.sin(theta) * getX() + Math.cos(theta) * getZ()
     );
   }
 
   public Vector3 rotateZ(double theta) {
     return new Vector3(
-      Math.cos(theta) * getX() - Math.sin(theta) * getY(),
-      Math.sin(theta) * getX() + Math.cos(theta) * getY(),
-      getZ()
+        Math.cos(theta) * getX() - Math.sin(theta) * getY(),
+        Math.sin(theta) * getX() + Math.cos(theta) * getY(),
+        getZ()
     );
   }
 

--- a/src/engine/WorldObject.java
+++ b/src/engine/WorldObject.java
@@ -9,6 +9,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class WorldObject {
+
   private final List<Vector3> vertices;
   private final List<Integer> edgeData;
   private Vector3 position;
@@ -32,7 +33,8 @@ public class WorldObject {
     loadFromFile(filename);
   }
 
-  public WorldObject(List<Vector3> vertices, List<Integer> edgeData, Vector3 position, Vector3 rotation) {
+  public WorldObject(List<Vector3> vertices, List<Integer> edgeData, Vector3 position,
+      Vector3 rotation) {
     this.vertices = vertices;
     this.edgeData = edgeData;
     this.position = position;
@@ -89,6 +91,7 @@ public class WorldObject {
   }
 
   public WorldObject clone() {
-    return new WorldObject(new ArrayList<>(vertices), new ArrayList<>(edgeData), position, rotation);
+    return new WorldObject(new ArrayList<>(vertices), new ArrayList<>(edgeData), position,
+        rotation);
   }
 }

--- a/src/shapes/Ellipse.java
+++ b/src/shapes/Ellipse.java
@@ -1,6 +1,7 @@
 package shapes;
 
 public final class Ellipse extends Shape {
+
   private final double a;
   private final double b;
   private final double rotation;
@@ -27,15 +28,15 @@ public final class Ellipse extends Shape {
   @Override
   public float nextX(double drawingProgress) {
     return (float) (position.getX()
-      + a * Math.cos(2 * Math.PI * drawingProgress) * Math.cos(rotation)
-      - b * Math.sin(2 * Math.PI * drawingProgress) * Math.sin(rotation));
+        + a * Math.cos(2 * Math.PI * drawingProgress) * Math.cos(rotation)
+        - b * Math.sin(2 * Math.PI * drawingProgress) * Math.sin(rotation));
   }
 
   @Override
   public float nextY(double drawingProgress) {
     return (float) (position.getY()
-      + a * Math.cos(2 * Math.PI * drawingProgress) * Math.sin(rotation)
-      + b * Math.sin(2 * Math.PI * drawingProgress) * Math.cos(rotation));
+        + a * Math.cos(2 * Math.PI * drawingProgress) * Math.sin(rotation)
+        + b * Math.sin(2 * Math.PI * drawingProgress) * Math.cos(rotation));
   }
 
   @Override

--- a/src/shapes/Line.java
+++ b/src/shapes/Line.java
@@ -1,6 +1,7 @@
 package shapes;
 
 public final class Line extends Shape {
+
   private final Vector2 a;
   private final Vector2 b;
 

--- a/src/shapes/Shape.java
+++ b/src/shapes/Shape.java
@@ -1,16 +1,22 @@
 package shapes;
 
 public abstract class Shape {
+
   public static final int DEFAULT_WEIGHT = 100;
 
   protected double weight;
   protected double length;
 
   public abstract float nextX(double drawingProgress);
+
   public abstract float nextY(double drawingProgress);
+
   public abstract Shape rotate(double theta);
+
   public abstract Shape scale(double factor);
+
   public abstract Shape translate(Vector2 vector);
+
   public abstract Shape setWeight(double weight);
 
   public double getWeight() {

--- a/src/shapes/Shape.java
+++ b/src/shapes/Shape.java
@@ -2,7 +2,7 @@ package shapes;
 
 public abstract class Shape {
 
-  public static final int DEFAULT_WEIGHT = 100;
+  public static final int DEFAULT_WEIGHT = 80;
 
   protected double weight;
   protected double length;

--- a/src/shapes/Shapes.java
+++ b/src/shapes/Shapes.java
@@ -13,7 +13,9 @@ import org.jgrapht.graph.DefaultUndirectedWeightedGraph;
 import org.jgrapht.graph.DefaultWeightedEdge;
 
 public class Shapes {
-  public static List<Shape> generatePolygram(int sides, int angleJump, Vector2 start, double weight) {
+
+  public static List<Shape> generatePolygram(int sides, int angleJump, Vector2 start,
+      double weight) {
     List<Shape> polygon = new ArrayList<>();
 
     double theta = angleJump * 2 * Math.PI / sides;
@@ -33,7 +35,8 @@ public class Shapes {
     return generatePolygram(sides, angleJump, start, Line.DEFAULT_WEIGHT);
   }
 
-  public static List<Shape> generatePolygram(int sides, int angleJump, double scale, double weight) {
+  public static List<Shape> generatePolygram(int sides, int angleJump, double scale,
+      double weight) {
     return generatePolygram(sides, angleJump, new Vector2(scale, scale), weight);
   }
 
@@ -59,16 +62,17 @@ public class Shapes {
 
   public static double totalLength(List<? extends Shape> shapes) {
     return shapes
-      .stream()
-      .map(Shape::getLength)
-      .reduce(Double::sum)
-      .orElse(0d);
+        .stream()
+        .map(Shape::getLength)
+        .reduce(Double::sum)
+        .orElse(0d);
   }
 
   // performs chinese postman on the input lines to get a path that will render cleanly on the oscilloscope.
   // TODO: Speed up.
   public static List<Shape> sortLines(List<Line> lines) {
-    Graph<Vector2, DefaultWeightedEdge> graph = new DefaultUndirectedWeightedGraph<>(DefaultWeightedEdge.class);
+    Graph<Vector2, DefaultWeightedEdge> graph = new DefaultUndirectedWeightedGraph<>(
+        DefaultWeightedEdge.class);
 
     for (Line line : lines) {
       graph.addVertex(line.getA());
@@ -79,7 +83,8 @@ public class Shapes {
       graph.setEdgeWeight(edge, line.length);
     }
 
-    ConnectivityInspector<Vector2, DefaultWeightedEdge> inspector = new ConnectivityInspector<>(graph);
+    ConnectivityInspector<Vector2, DefaultWeightedEdge> inspector = new ConnectivityInspector<>(
+        graph);
 
     List<Shape> sortedLines = new ArrayList<>();
 

--- a/src/shapes/Vector2.java
+++ b/src/shapes/Vector2.java
@@ -2,7 +2,8 @@ package shapes;
 
 import java.util.Objects;
 
-public final class Vector2 extends Shape{
+public final class Vector2 extends Shape {
+
   private final double x;
   private final double y;
 
@@ -75,11 +76,15 @@ public final class Vector2 extends Shape{
 
   @Override
   public boolean equals(Object obj) {
-    if (this == obj) return true;
-    if (obj == null || getClass() != obj.getClass()) return false;
+    if (this == obj) {
+      return true;
+    }
+    if (obj == null || getClass() != obj.getClass()) {
+      return false;
+    }
     Vector2 point = (Vector2) obj;
     return round(x, 2) == round(point.x, 2)
-      && round(y, 2) == round(point.y, 2);
+        && round(y, 2) == round(point.y, 2);
   }
 
   @Override
@@ -88,7 +93,9 @@ public final class Vector2 extends Shape{
   }
 
   private static double round(double value, int places) {
-    if (places < 0) throw new IllegalArgumentException();
+    if (places < 0) {
+      throw new IllegalArgumentException();
+    }
 
     long factor = (long) Math.pow(10, places);
     value *= factor;


### PR DESCRIPTION
## New features:
### Now supports 'Auto-scaling'
- Passing in arguments for the position of the camera is not required
    - Just pass in the object file (with optional rotation speed and focal length) and image scaling is done for you
    - Position arguments can still be passed in to override the auto-scaling
- This moves the z-position of the camera and does a sample renders of the object being rotated
    - By rotating the object we get an idea of the max abs. value its vertices can have
    - We keep moving the camera back until the max abs. value is less than VERTEX_VALUE_THRESHOLD (Should stay at 1)

### Refactoring:

- Move argument processing out of AudioClient class into separate AudioArgs class
- Put frame pre-rendering in separate function in AudioClient
- Create another AudioPlayer constructor for code reduction in main