### PR TITLE
Implement loading a whole folder of files

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>sh.ball</groupId>
     <artifactId>osci-render</artifactId>
-    <version>1.8.2</version>
+    <version>1.9.0</version>
 
     <name>osci-render</name>
 

--- a/src/main/java/sh/ball/gui/Controller.java
+++ b/src/main/java/sh/ball/gui/Controller.java
@@ -134,6 +134,7 @@ public class Controller implements Initializable, FrequencyListener, Listener {
     this.audioPlayer = audioPlayer;
     FrameSet<List<Shape>> frames = new ObjParser(DEFAULT_OBJ).parse();
     frameSets.add(frames);
+    frameSetPaths.add("cube.obj");
     currentFrameSet = 0;
     frames.addListener(this);
     this.producer = new FrameProducer<>(audioPlayer, frames);

--- a/src/main/java/sh/ball/gui/Controller.java
+++ b/src/main/java/sh/ball/gui/Controller.java
@@ -79,6 +79,8 @@ public class Controller implements Initializable, FrequencyListener, Listener {
   @FXML
   private Label fileLabel;
   @FXML
+  private Label jkLabel;
+  @FXML
   private Button recordButton;
   @FXML
   private Label recordLabel;
@@ -412,20 +414,21 @@ public class Controller implements Initializable, FrequencyListener, Listener {
   private void chooseFile(File chosenFile) {
     try {
       if (chosenFile.exists()) {
-        String path = chosenFile.getAbsolutePath();
         frameSets.clear();
         frameSetPaths.clear();
 
         if (chosenFile.isDirectory()) {
+          jkLabel.setVisible(true);
           for (File file : chosenFile.listFiles()) {
             try {
               frameSets.add(ParserFactory.getParser(file.getAbsolutePath()).parse());
-              frameSetPaths.add(file.getAbsolutePath());
+              frameSetPaths.add(file.getName());
             } catch (IOException ignored) {}
           }
         } else {
-          frameSets.add(ParserFactory.getParser(path).parse());
-          frameSetPaths.add(path);
+          jkLabel.setVisible(false);
+          frameSets.add(ParserFactory.getParser(chosenFile.getAbsolutePath()).parse());
+          frameSetPaths.add(chosenFile.getName());
         }
 
         currentFrameSet = 0;

--- a/src/main/java/sh/ball/gui/Controller.java
+++ b/src/main/java/sh/ball/gui/Controller.java
@@ -365,25 +365,28 @@ public class Controller implements Initializable, FrequencyListener, Listener {
     }
   }
 
+  private void changeFrameSet(FrameSet<List<Shape>> frames) {
+    frames.addListener(this);
+    producer = new FrameProducer<>(audioPlayer, frames);
+
+    updateObjectRotateSpeed();
+    updateFocalLength();
+    executor.submit(producer);
+
+    KeyFrame kf1 = new KeyFrame(Duration.seconds(0), e -> wobbleEffect.setVolume(0));
+    KeyFrame kf2 = new KeyFrame(Duration.seconds(1), e -> {
+      wobbleEffect.update();
+      wobbleEffect.setVolume(wobbleSlider.getValue());
+    });
+    Timeline timeline = new Timeline(kf1, kf2);
+    Platform.runLater(timeline::play);
+  }
+
   private void chooseFile(File file) {
     try {
       producer.stop();
       String path = file.getAbsolutePath();
-      FrameSet<List<Shape>> frames = ParserFactory.getParser(path).parse();
-      frames.addListener(this);
-      producer = new FrameProducer<>(audioPlayer, frames);
-
-      updateObjectRotateSpeed();
-      updateFocalLength();
-      executor.submit(producer);
-
-      KeyFrame kf1 = new KeyFrame(Duration.seconds(0), e -> wobbleEffect.setVolume(0));
-      KeyFrame kf2 = new KeyFrame(Duration.seconds(1), e -> {
-        wobbleEffect.update();
-        wobbleEffect.setVolume(wobbleSlider.getValue());
-      });
-      Timeline timeline = new Timeline(kf1, kf2);
-      Platform.runLater(timeline::play);
+      changeFrameSet(ParserFactory.getParser(path).parse());
 
       if (file.exists() && !file.isDirectory()) {
         fileLabel.setText(path);

--- a/src/main/java/sh/ball/gui/Controller.java
+++ b/src/main/java/sh/ball/gui/Controller.java
@@ -61,6 +61,7 @@ public class Controller implements Initializable, FrequencyListener, Listener {
   private FrequencyAnalyser<List<Shape>> analyser;
   private final AudioDevice defaultDevice;
   private boolean recording = false;
+  private String lastVisitedDirectory;
 
   private FrameProducer<List<Shape>> producer;
   private final List<FrameSet<List<Shape>>> frameSets = new ArrayList<>();
@@ -247,6 +248,7 @@ public class Controller implements Initializable, FrequencyListener, Listener {
       File file = fileChooser.showOpenDialog(stage);
       if (file != null) {
         chooseFile(file);
+        updateLastVisitedDirectory(new File(file.getParent()));
       }
     });
 
@@ -254,6 +256,7 @@ public class Controller implements Initializable, FrequencyListener, Listener {
       File file = folderChooser.showDialog(stage);
       if (file != null) {
         chooseFile(file);
+        updateLastVisitedDirectory(file);
       }
     });
 
@@ -279,6 +282,13 @@ public class Controller implements Initializable, FrequencyListener, Listener {
         switchAudioDevice(newDevice);
       }
     });
+  }
+
+  private void updateLastVisitedDirectory(File file) {
+    lastVisitedDirectory = file != null ? file.getAbsolutePath() : System.getProperty("user.home");
+    File dir = new File(lastVisitedDirectory);
+    fileChooser.setInitialDirectory(dir);
+    folderChooser.setInitialDirectory(dir);
   }
 
   private void switchAudioDevice(AudioDevice device) {

--- a/src/main/java/sh/ball/gui/Gui.java
+++ b/src/main/java/sh/ball/gui/Gui.java
@@ -12,7 +12,6 @@ import javafx.scene.input.MouseEvent;
 import javafx.stage.Stage;
 import sh.ball.audio.ShapeAudioPlayer;
 import sh.ball.audio.engine.ConglomerateAudioEngine;
-import sh.ball.audio.engine.JavaAudioEngine;
 import sh.ball.engine.Vector3;
 
 import java.util.Objects;

--- a/src/main/java/sh/ball/gui/Gui.java
+++ b/src/main/java/sh/ball/gui/Gui.java
@@ -36,8 +36,8 @@ public class Gui extends Application {
 
     scene.addEventHandler(KeyEvent.KEY_PRESSED, (event -> {
       switch (event.getCode()) {
-        case K -> controller.previousFrameSet();
         case J -> controller.nextFrameSet();
+        case K -> controller.previousFrameSet();
       }
     }));
 

--- a/src/main/java/sh/ball/gui/Gui.java
+++ b/src/main/java/sh/ball/gui/Gui.java
@@ -33,20 +33,30 @@ public class Gui extends Application {
     stage.setTitle("osci-render");
     Scene scene = new Scene(root);
     scene.getStylesheets().add(getClass().getResource("/css/main.css").toExternalForm());
+
+    scene.addEventHandler(KeyEvent.KEY_PRESSED, (event -> {
+      switch (event.getCode()) {
+        case K -> controller.previousFrameSet();
+        case J -> controller.nextFrameSet();
+      }
+    }));
+
     scene.addEventFilter(MouseEvent.MOUSE_MOVED, event -> {
       if (controller.mouseRotate()) {
         controller.setObjRotate(new Vector3(
           3 * Math.PI * (event.getSceneY() / scene.getHeight()),
-          3 * Math.PI * (event.getSceneX() /  scene.getWidth()),
+          3 * Math.PI * (event.getSceneX() / scene.getWidth()),
           0
         ));
       }
     });
+
     scene.addEventHandler(KeyEvent.KEY_PRESSED, t -> {
       if (t.getCode() == KeyCode.ESCAPE) {
         controller.disableMouseRotate();
       }
     });
+
     stage.setScene(scene);
     stage.setResizable(false);
 

--- a/src/main/resources/fxml/osci-render.fxml
+++ b/src/main/resources/fxml/osci-render.fxml
@@ -16,10 +16,11 @@
        <Button fx:id="chooseFileButton" layoutX="14.0" layoutY="53.0" mnemonicParsing="false" prefHeight="26.0" prefWidth="114.0" text="Choose File" />
        <Label fx:id="fileLabel" layoutX="144.0" layoutY="57.0" maxWidth="270.0" prefHeight="18.0" prefWidth="246.0" text="cube.obj" />
          <Button fx:id="recordButton" layoutX="14.0" layoutY="129.0" mnemonicParsing="false" prefHeight="26.0" prefWidth="114.0" text="Record" />
-         <Label fx:id="recordLabel" layoutX="145.0" layoutY="140.0" maxWidth="270.0" prefHeight="18.0" prefWidth="245.0" />
+         <Label fx:id="recordLabel" layoutX="144.0" layoutY="133.0" maxWidth="270.0" prefHeight="18.0" prefWidth="245.0" />
          <Label id="frequency" fx:id="frequencyLabel" layoutX="13.0" layoutY="166.0" prefHeight="58.0" prefWidth="376.0" text="L/R Frequency:&#10; &#10;" />
          <ComboBox fx:id="deviceComboBox" layoutX="14.0" layoutY="11.0" prefHeight="26.0" prefWidth="376.0" />
          <Button fx:id="chooseFolderButton" layoutX="14.0" layoutY="91.0" mnemonicParsing="false" prefHeight="26.0" prefWidth="114.0" text="Choose Folder" />
+         <Label fx:id="jkLabel" layoutX="143.0" layoutY="95.0" maxWidth="270.0" prefHeight="18.0" prefWidth="246.0" text="Use j and k to cycle between files" visible="false" />
       </children>
    </AnchorPane>
    <TitledPane animated="false" collapsible="false" layoutX="423.0" layoutY="252.0" prefHeight="272.0" prefWidth="402.0" text="Effects">

--- a/src/main/resources/fxml/osci-render.fxml
+++ b/src/main/resources/fxml/osci-render.fxml
@@ -10,18 +10,19 @@
 <?import javafx.scene.layout.AnchorPane?>
 <?import javafx.scene.text.Font?>
 
-<AnchorPane prefHeight="498.0" prefWidth="837.0" xmlns="http://javafx.com/javafx/16" xmlns:fx="http://javafx.com/fxml/1">
-   <AnchorPane id="control-pane" layoutX="422.0" layoutY="10.0" prefHeight="195.0" prefWidth="402.0">
+<AnchorPane prefHeight="539.0" prefWidth="837.0" xmlns="http://javafx.com/javafx/16" xmlns:fx="http://javafx.com/fxml/1">
+   <AnchorPane id="control-pane" layoutX="423.0" layoutY="14.0" prefHeight="232.0" prefWidth="402.0">
       <children>
        <Button fx:id="chooseFileButton" layoutX="14.0" layoutY="53.0" mnemonicParsing="false" prefHeight="26.0" prefWidth="114.0" text="Choose File" />
-       <Label fx:id="fileLabel" layoutX="146.0" layoutY="58.0" maxWidth="270.0" prefHeight="18.0" prefWidth="246.0" text="cube.obj" />
-         <Button fx:id="recordButton" layoutX="14.0" layoutY="93.0" mnemonicParsing="false" prefHeight="26.0" prefWidth="114.0" text="Record" />
-         <Label fx:id="recordLabel" layoutX="146.0" layoutY="98.0" maxWidth="270.0" prefHeight="18.0" prefWidth="245.0" />
-         <Label id="frequency" fx:id="frequencyLabel" layoutX="14.0" layoutY="131.0" prefHeight="58.0" prefWidth="376.0" text="L/R Frequency:&#10; &#10;" />
+       <Label fx:id="fileLabel" layoutX="144.0" layoutY="57.0" maxWidth="270.0" prefHeight="18.0" prefWidth="246.0" text="cube.obj" />
+         <Button fx:id="recordButton" layoutX="14.0" layoutY="129.0" mnemonicParsing="false" prefHeight="26.0" prefWidth="114.0" text="Record" />
+         <Label fx:id="recordLabel" layoutX="145.0" layoutY="140.0" maxWidth="270.0" prefHeight="18.0" prefWidth="245.0" />
+         <Label id="frequency" fx:id="frequencyLabel" layoutX="13.0" layoutY="166.0" prefHeight="58.0" prefWidth="376.0" text="L/R Frequency:&#10; &#10;" />
          <ComboBox fx:id="deviceComboBox" layoutX="14.0" layoutY="11.0" prefHeight="26.0" prefWidth="376.0" />
+         <Button fx:id="chooseFolderButton" layoutX="14.0" layoutY="91.0" mnemonicParsing="false" prefHeight="26.0" prefWidth="114.0" text="Choose Folder" />
       </children>
    </AnchorPane>
-   <TitledPane animated="false" collapsible="false" layoutX="422.0" layoutY="213.0" prefHeight="272.0" prefWidth="402.0" text="Effects">
+   <TitledPane animated="false" collapsible="false" layoutX="423.0" layoutY="252.0" prefHeight="272.0" prefWidth="402.0" text="Effects">
      <content>
        <AnchorPane minHeight="0.0" minWidth="0.0" prefHeight="246.0" prefWidth="442.0">
             <children>
@@ -39,7 +40,7 @@
          </AnchorPane>
      </content>
    </TitledPane>
-<TitledPane fx:id="objTitledPane" animated="false" collapsible="false" layoutX="11.0" layoutY="275.0" maxHeight="-Infinity" maxWidth="-Infinity" prefHeight="210.0" prefWidth="402.0" text="3D .obj file settings">
+<TitledPane fx:id="objTitledPane" animated="false" collapsible="false" layoutX="12.0" layoutY="280.0" maxHeight="-Infinity" maxWidth="-Infinity" prefHeight="244.0" prefWidth="402.0" text="3D .obj file settings">
   <AnchorPane minHeight="0.0" minWidth="0.0" prefHeight="180.0" prefWidth="359.0">
     <Slider fx:id="focalLengthSlider" blockIncrement="0.01" layoutX="116.0" layoutY="15.0" majorTickUnit="0.2" max="2.0" min="1.0E-5" prefHeight="38.0" prefWidth="270.0" showTickLabels="true" showTickMarks="true" value="1.0" />
     <Label layoutX="30.0" layoutY="14.0" text="Focal length" />
@@ -55,7 +56,7 @@
          <CheckBox fx:id="rotateCheckBox" layoutX="90.0" layoutY="147.0" mnemonicParsing="false" text="Rotate with Mouse (Esc to disable)" />
   </AnchorPane>
 </TitledPane>
-   <TitledPane collapsible="false" layoutX="11.0" layoutY="9.0" prefHeight="257.0" prefWidth="402.0" text="Image settings">
+   <TitledPane collapsible="false" layoutX="12.0" layoutY="14.0" prefHeight="257.0" prefWidth="402.0" text="Image settings">
       <content>
       <AnchorPane minHeight="0.0" minWidth="0.0">
         <Slider fx:id="rotateSpeedSlider" blockIncrement="0.05" layoutX="116.0" layoutY="90.0" majorTickUnit="1.0" max="10.0" prefHeight="38.0" prefWidth="270.0" showTickLabels="true" showTickMarks="true" />


### PR DESCRIPTION
## New features

- Added 'Choose Folder' button to select a folder containing `.txt`, `.obj`, and `.svg` files
  - Cycle between the files in the folder using `j` and `k` on your keyboard
- File choosers now remember the location you last opened a file from

