### PR TITLE
Add Playback Controls for Multiple Files

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>sh.ball</groupId>
     <artifactId>osci-render</artifactId>
-    <version>1.15.0</version>
+    <version>1.16.0</version>
 
     <name>osci-render</name>
 

--- a/src/main/java/sh/ball/gui/Controller.java
+++ b/src/main/java/sh/ball/gui/Controller.java
@@ -761,10 +761,10 @@ public class Controller implements Initializable, FrequencyListener, MidiListene
   private void updateFrameLabels() {
     if (framesPlaying) {
       fileLabel.setText("Frame rate: " + frameRate);
-      jkLabel.setText("Use u and o to decrease and increase the frame rate, or i to toggle playback");
+      jkLabel.setText("Use u and o to decrease and increase the frame rate, or i to stop playback");
     } else {
       fileLabel.setText(frameSourcePaths.get(currentFrameSource));
-      jkLabel.setText("Use j and k (or MIDI Program Change) to cycle between files, or i to toggle playback");
+      jkLabel.setText("Use j and k (or MIDI Program Change) to cycle between files, or i to start playback");
     }
   }
 

--- a/src/main/java/sh/ball/gui/Controller.java
+++ b/src/main/java/sh/ball/gui/Controller.java
@@ -759,9 +759,10 @@ public class Controller implements Initializable, FrequencyListener, MidiListene
 
   // ==================== Start code block by DJ_Level_3 ====================
   //
-  //     Quickly written code by DJ_Level_3, a programmer who is quite
-  // inexperienced with Java. Almost definitely could be made better
-  // somehow. However, testing so far shows that (insert results).
+  //     Quickly written code by DJ_Level_3, a programmer who is not super
+  // experienced with Java. It almost definitely could be made better in one
+  // way or another, but testing so far shows that the code is stable and
+  // doesn't noticeably decrease performance.
   //
 
   // toggles frameSource playback after pressing 'i'

--- a/src/main/java/sh/ball/gui/Gui.java
+++ b/src/main/java/sh/ball/gui/Gui.java
@@ -33,8 +33,13 @@ public class Gui extends Application {
 
     scene.addEventHandler(KeyEvent.KEY_PRESSED, (event -> {
       switch (event.getCode()) {
+        // frame selection controls
         case J -> controller.nextFrameSet();
         case K -> controller.previousFrameSource();
+        // playback controls
+        case U -> controller.decreaseFrameRate();
+        case I -> controller.togglePlayback();
+        case O -> controller.increaseFrameRate();
       }
     }));
 

--- a/src/main/java/sh/ball/gui/Gui.java
+++ b/src/main/java/sh/ball/gui/Gui.java
@@ -34,7 +34,7 @@ public class Gui extends Application {
     scene.addEventHandler(KeyEvent.KEY_PRESSED, (event -> {
       switch (event.getCode()) {
         // frame selection controls
-        case J -> controller.nextFrameSet();
+        case J -> controller.nextFrameSource();
         case K -> controller.previousFrameSource();
         // playback controls
         case U -> controller.decreaseFrameRate();

--- a/src/main/resources/fxml/osci-render.fxml
+++ b/src/main/resources/fxml/osci-render.fxml
@@ -65,7 +65,7 @@
          <Label id="frequency" fx:id="frequencyLabel" layoutX="13.0" layoutY="206.0" prefHeight="58.0" prefWidth="376.0" text="L/R Frequency:&#10; &#10;" />
          <ComboBox fx:id="deviceComboBox" layoutX="14.0" layoutY="11.0" prefWidth="376.0" />
          <Button fx:id="chooseFolderButton" layoutX="14.0" layoutY="91.0" mnemonicParsing="false" prefHeight="26.0" prefWidth="114.0" text="Choose Folder" />
-         <Label fx:id="jkLabel" layoutX="143.0" layoutY="84.0" maxWidth="270.0" prefHeight="43.0" prefWidth="246.0" text="Use j and k (or MIDI Program Change) to cycle between files, or i to toggle playback" visible="false" wrapText="true" />
+         <Label fx:id="jkLabel" layoutX="143.0" layoutY="84.0" maxWidth="270.0" prefHeight="43.0" prefWidth="246.0" text="Use j and k (or MIDI Program Change) to cycle between files, or i to start playback" visible="false" wrapText="true" />
          <TextField fx:id="recordTextField" disable="true" layoutX="300.0" layoutY="154.0" prefHeight="26.0" prefWidth="70.0" text="2.0" />
          <Label fx:id="recordLengthLabel" disable="true" layoutX="290.0" layoutY="128.0" text="Record length (s)" />
          <CheckBox fx:id="recordCheckBox" layoutX="143.0" layoutY="146.0" mnemonicParsing="false" text="Timed record" />

--- a/src/main/resources/fxml/osci-render.fxml
+++ b/src/main/resources/fxml/osci-render.fxml
@@ -59,14 +59,13 @@
    <AnchorPane id="control-pane" layoutX="10.0" layoutY="37.0" prefHeight="313.0" prefWidth="402.0">
       <children>
          <Button fx:id="chooseFileButton" layoutX="14.0" layoutY="53.0" mnemonicParsing="false" prefHeight="26.0" prefWidth="114.0" text="Choose File" />
-         <Label fx:id="fileLabel" layoutX="144.0" layoutY="57.0" maxWidth="270.0" prefHeight="18.0" prefWidth="246.0" text="cube.obj" />
+         <Label fx:id="fileLabel" layoutX="143.0" layoutY="57.0" maxWidth="270.0" prefHeight="18.0" prefWidth="246.0" text="cube.obj" />
          <Button fx:id="recordButton" layoutX="13.0" layoutY="142.0" mnemonicParsing="false" prefHeight="26.0" prefWidth="114.0" text="Record" />
          <Label fx:id="recordLabel" layoutX="13.0" layoutY="184.0" maxWidth="358.0" prefHeight="18.0" prefWidth="357.0" />
          <Label id="frequency" fx:id="frequencyLabel" layoutX="13.0" layoutY="206.0" prefHeight="58.0" prefWidth="376.0" text="L/R Frequency:&#10; &#10;" />
          <ComboBox fx:id="deviceComboBox" layoutX="14.0" layoutY="11.0" prefWidth="376.0" />
          <Button fx:id="chooseFolderButton" layoutX="14.0" layoutY="91.0" mnemonicParsing="false" prefHeight="26.0" prefWidth="114.0" text="Choose Folder" />
-         <Label fx:id="jkLabel" layoutX="143.0" layoutY="84.0" maxWidth="270.0" prefHeight="43.0" prefWidth="246.0" text="Use j and k (or MIDI Program Change) to cycle between files" visible="false" wrapText="true" />
-         <Label fx:id="uioLabel" layoutX="143.0" layoutY="84.0" maxWidth="270.0" prefHeight="43.0" prefWidth="246.0" text="Use u and o to change the framerate" visible="false" wrapText="true" />
+         <Label fx:id="jkLabel" layoutX="143.0" layoutY="84.0" maxWidth="270.0" prefHeight="43.0" prefWidth="246.0" text="Use j and k (or MIDI Program Change) to cycle between files, or i to toggle playback" visible="false" wrapText="true" />
          <TextField fx:id="recordTextField" disable="true" layoutX="300.0" layoutY="154.0" prefHeight="26.0" prefWidth="70.0" text="2.0" />
          <Label fx:id="recordLengthLabel" disable="true" layoutX="290.0" layoutY="128.0" text="Record length (s)" />
          <CheckBox fx:id="recordCheckBox" layoutX="143.0" layoutY="146.0" mnemonicParsing="false" text="Timed record" />

--- a/src/main/resources/fxml/osci-render.fxml
+++ b/src/main/resources/fxml/osci-render.fxml
@@ -66,6 +66,7 @@
          <ComboBox fx:id="deviceComboBox" layoutX="14.0" layoutY="11.0" prefWidth="376.0" />
          <Button fx:id="chooseFolderButton" layoutX="14.0" layoutY="91.0" mnemonicParsing="false" prefHeight="26.0" prefWidth="114.0" text="Choose Folder" />
          <Label fx:id="jkLabel" layoutX="143.0" layoutY="84.0" maxWidth="270.0" prefHeight="43.0" prefWidth="246.0" text="Use j and k (or MIDI Program Change) to cycle between files" visible="false" wrapText="true" />
+         <Label fx:id="uioLabel" layoutX="143.0" layoutY="84.0" maxWidth="270.0" prefHeight="43.0" prefWidth="246.0" text="Use u and o to change the framerate" visible="false" wrapText="true" />
          <TextField fx:id="recordTextField" disable="true" layoutX="300.0" layoutY="154.0" prefHeight="26.0" prefWidth="70.0" text="2.0" />
          <Label fx:id="recordLengthLabel" disable="true" layoutX="290.0" layoutY="128.0" text="Record length (s)" />
          <CheckBox fx:id="recordCheckBox" layoutX="143.0" layoutY="146.0" mnemonicParsing="false" text="Timed record" />


### PR DESCRIPTION
This pull request adds code for playback when a folder is selected, which play the files one by one at a selected framerate. When in playback mode, the hint about changing files changes to a hint about playback controls. Code is properly commented and has protections against common bugs such as setting invalid framerate values.

Changes:

```
Modified files:
- Gui.java (add hotkeys)
- Controller.java (add code for playback and UI modifications)
- osci-render.fxml (add info on playback controls to UI)

New hotkeys:
- i -> play opened files one by one
- u -> decrease playback rate, down to 1 frame per second
- o -> increase playback rate, up to 120 frames per second
```