### PR TITLE
Add sorting to directory code

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>sh.ball</groupId>
     <artifactId>osci-render</artifactId>
-    <version>1.16.0</version>
+    <version>1.16.1</version>
 
     <name>osci-render</name>
 

--- a/src/main/java/sh/ball/gui/Controller.java
+++ b/src/main/java/sh/ball/gui/Controller.java
@@ -695,7 +695,9 @@ public class Controller implements Initializable, FrequencyListener, MidiListene
         List<byte[]> files = new ArrayList<>();
         List<String> names = new ArrayList<>();
         if (chosenFile.isDirectory()) {
-          for (File file : Objects.requireNonNull(chosenFile.listFiles())) {
+          File[] fileList = Objects.requireNonNull(chosenFile.listFiles());
+          Arrays.sort(fileList);
+          for (File file : fileList) {
             files.add(Files.readAllBytes(file.toPath()));
             names.add(file.getName());
           }


### PR DESCRIPTION
Sort the files in a directory in alphabetical order before selecting them, preventing issues on some systems where directories will open in strange, non-alphabetical orders.

(I recommend making this a 1.16.1 patch instead of 1.17.0 since this isn't a feature addition)