### PR TITLE
Support e notation in SVGs, and correctly skip over small shapes when rendering

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>sh.ball</groupId>
     <artifactId>osci-render</artifactId>
-    <version>1.16.1</version>
+    <version>1.16.2</version>
 
     <name>osci-render</name>
 

--- a/src/main/java/sh/ball/audio/ShapeAudioPlayer.java
+++ b/src/main/java/sh/ball/audio/ShapeAudioPlayer.java
@@ -112,11 +112,17 @@ public class ShapeAudioPlayer implements AudioPlayer<List<Shape>> {
       count = 0;
     }
 
-    if (shapeDrawn > length) {
-      // We do -= length here rather than resetting to 0 since it is correct
-      // to skip a small bit of the next shape, in line with the length increment
+    // Need to skip all shapes that the lengthIncrement draws over.
+    // This is especially an issue when there are lots of small lines being
+    // drawn.
+    while (shapeDrawn > length) {
       shapeDrawn -= length;
       currentShape++;
+      // otherwise, index out of bounds
+      if (currentShape >= frame.size()) {
+        break;
+      }
+      length = getCurrentShape().getLength();
     }
 
     double proportionalLength = trace * frameLength;

--- a/src/main/java/sh/ball/gui/Controller.java
+++ b/src/main/java/sh/ball/gui/Controller.java
@@ -89,8 +89,8 @@ public class Controller implements Initializable, FrequencyListener, MidiListene
   // frames
   private static final InputStream DEFAULT_OBJ = Controller.class.getResourceAsStream("/models/cube.obj");
   private final ExecutorService executor = Executors.newSingleThreadExecutor();
-  private final List<byte[]> openFiles = new ArrayList<>();
-  private final List<String> frameSourcePaths = new ArrayList<>();
+  private List<byte[]> openFiles = new ArrayList<>();
+  private List<String> frameSourcePaths = new ArrayList<>();
   private List<FrameSource<List<Shape>>> frameSources = new ArrayList<>();
   private FrameProducer<List<Shape>> producer;
   private int currentFrameSource;
@@ -669,23 +669,27 @@ public class Controller implements Initializable, FrequencyListener, MidiListene
   }
 
   private void updateFiles(List<byte[]> files, List<String> names) throws IOException, ParserConfigurationException, SAXException {
-    List<FrameSource<List<Shape>>> oldFrameSources = frameSources;
-    frameSources = new ArrayList<>();
-    frameSourcePaths.clear();
-    openFiles.clear();
-    jkLabel.setVisible(files.size() > 1);
-    framesPlaying = framesPlaying && files.size() > 1;
+    List<FrameSource<List<Shape>>> newFrameSources = new ArrayList<>();
+    List<String> newFrameSourcePaths = new ArrayList<>();
+    List<byte[]> newOpenFiles = new ArrayList<>();
 
     for (int i = 0; i < files.size(); i++) {
       try {
-        frameSources.add(ParserFactory.getParser(names.get(i), files.get(i)).parse());
-        frameSourcePaths.add(names.get(i));
-        openFiles.add(files.get(i));
+        newFrameSources.add(ParserFactory.getParser(names.get(i), files.get(i)).parse());
+        newFrameSourcePaths.add(names.get(i));
+        newOpenFiles.add(files.get(i));
       } catch (IOException ignored) {}
     }
 
-    oldFrameSources.forEach(FrameSource::disable);
-    changeFrameSource(0);
+    if (newFrameSources.size() > 0) {
+      jkLabel.setVisible(newFrameSources.size() > 1);
+      framesPlaying = framesPlaying && newFrameSources.size() > 1;
+      frameSources.forEach(FrameSource::disable);
+      frameSources = newFrameSources;
+      frameSourcePaths = newFrameSourcePaths;
+      openFiles = newOpenFiles;
+      changeFrameSource(0);
+    }
   }
 
   // selects a new file or folder for files to be rendered from

--- a/src/main/java/sh/ball/parser/svg/MoveTo.java
+++ b/src/main/java/sh/ball/parser/svg/MoveTo.java
@@ -11,7 +11,10 @@ class MoveTo {
   // Parses moveto commands (M and m commands)
   private static List<Shape> parseMoveTo(SvgState state, List<Float> args, boolean isAbsolute) {
     if (args.size() % 2 != 0 || args.size() < 2) {
-      throw new IllegalArgumentException("SVG moveto command has incorrect number of arguments.");
+      for (Float arg : args) {
+        System.out.println(arg);
+      }
+      throw new IllegalArgumentException("SVG moveto command has incorrect number of arguments.\n");
     }
 
     Vector2 vec = new Vector2(args.get(0), args.get(1));

--- a/src/main/java/sh/ball/parser/svg/SvgParser.java
+++ b/src/main/java/sh/ball/parser/svg/SvgParser.java
@@ -77,7 +77,7 @@ public class SvgParser extends FileParser<FrameSource<List<Shape>>> {
   private String[] preProcessPath(String path) throws IllegalArgumentException {
     // Replace all commas with spaces and then remove unnecessary whitespace
     path = path.replace(',', ' ');
-    path = path.replace("-", " -");
+    path = path.replaceAll("(?<!e)-", " -");
     path = path.replaceAll("\\s+", " ");
     path = path.replaceAll("(^\\s|\\s$)", "");
 
@@ -112,6 +112,7 @@ public class SvgParser extends FileParser<FrameSource<List<Shape>>> {
         }
       }
     } catch (Exception e) {
+      e.printStackTrace();
       System.out.println(Arrays.toString(decimalSplit));
       System.out.println(command);
     }


### PR DESCRIPTION
### Changes

- Much better rendering of complex shapes, particularly SVGs with a lot of detail
- e notation in SVG paths is now supported
  - e.g. 7e-5

closes #40 