### PR TITLE
Smoothly transition between objects, and have consistent sound for all objects

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>sh.ball</groupId>
     <artifactId>osci-render</artifactId>
-    <version>1.16.2</version>
+    <version>1.16.3</version>
 
     <name>osci-render</name>
 

--- a/src/main/java/sh/ball/audio/FrameProducer.java
+++ b/src/main/java/sh/ball/audio/FrameProducer.java
@@ -20,4 +20,8 @@ public class FrameProducer<S> implements Runnable {
   public void setFrameSettings(Object settings) {
     frames.setFrameSettings(settings);
   }
+
+  public Object getFrameSettings() {
+    return frames.getFrameSettings();
+  }
 }

--- a/src/main/java/sh/ball/audio/FrameSource.java
+++ b/src/main/java/sh/ball/audio/FrameSource.java
@@ -11,4 +11,6 @@ public interface FrameSource<T> {
   void enable();
 
   void setFrameSettings(Object settings);
+
+  Object getFrameSettings();
 }

--- a/src/main/java/sh/ball/audio/ShapeAudioPlayer.java
+++ b/src/main/java/sh/ball/audio/ShapeAudioPlayer.java
@@ -33,7 +33,7 @@ public class ShapeAudioPlayer implements AudioPlayer<List<Shape>> {
   private static final double MIN_TRACE = 0.001;
   // Arbitrary max count for effects
   private static final int MAX_COUNT = 10000;
-  private static final int BUFFER_SIZE = 5;
+  private static final int BUFFER_SIZE = 10;
   // Is this always true? Might need to check from AudioEngine
   private static final int BITS_PER_SAMPLE = 16;
   private static final boolean SIGNED = true;

--- a/src/main/java/sh/ball/engine/WorldObject.java
+++ b/src/main/java/sh/ball/engine/WorldObject.java
@@ -4,10 +4,7 @@ import com.mokiat.data.front.parser.*;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 import org.jgrapht.Graph;
 import org.jgrapht.alg.connectivity.ConnectivityInspector;
@@ -131,7 +128,7 @@ public class WorldObject {
       return Set.of();
     }
 
-    Set<Line3D> edges = new HashSet<>();
+    Set<Line3D> edges = new LinkedHashSet<>();
 
     for (OBJVertex vertex : model.getVertices()) {
       objVertices.add(new Vector3(vertex.x, vertex.y, vertex.z));

--- a/src/main/java/sh/ball/gui/Controller.java
+++ b/src/main/java/sh/ball/gui/Controller.java
@@ -54,6 +54,7 @@ import sh.ball.audio.midi.MidiCommunicator;
 import sh.ball.audio.midi.MidiListener;
 import sh.ball.audio.midi.MidiNote;
 import sh.ball.engine.Vector3;
+import sh.ball.parser.obj.ObjFrameSettings;
 import sh.ball.parser.obj.ObjSettingsFactory;
 import sh.ball.parser.obj.ObjParser;
 import sh.ball.parser.ParserFactory;
@@ -645,12 +646,16 @@ public class Controller implements Initializable, FrequencyListener, MidiListene
     FrameSource<List<Shape>> frames = frameSources.get(index);
     frameSources.forEach(FrameSource::disable);
     frames.enable();
+
+    Object oldSettings = producer.getFrameSettings();
     producer = new FrameProducer<>(audioPlayer, frames);
 
     // Apply the same settings that the previous frameSource had
     updateObjectRotateSpeed(objectRotateSpeedSlider.getValue());
     updateFocalLength(focalLengthSlider.getValue());
-    setObjRotate(rotation);
+    if (oldSettings instanceof ObjFrameSettings settings) {
+      setObjRotate(settings.baseRotation, settings.currentRotation);
+    }
     executor.submit(producer);
 
     // apply the wobble effect after a second as the frequency of the audio takes a while to
@@ -843,10 +848,15 @@ public class Controller implements Initializable, FrequencyListener, MidiListene
     rotateCheckBox.setSelected(false);
   }
 
-  // updates the 3D object rotation angle
+  // updates the 3D object base rotation angle
   protected void setObjRotate(Vector3 vector) {
     rotation = vector;
-    producer.setFrameSettings(ObjSettingsFactory.rotation(vector));
+    producer.setFrameSettings(ObjSettingsFactory.baseRotation(vector));
+  }
+
+  // updates the 3D object base and current rotation angle
+  protected void setObjRotate(Vector3 baseRotation, Vector3 currentRotation) {
+    producer.setFrameSettings(ObjSettingsFactory.rotation(baseRotation, currentRotation));
   }
 
   @Override

--- a/src/main/java/sh/ball/parser/obj/ObjFrameSettings.java
+++ b/src/main/java/sh/ball/parser/obj/ObjFrameSettings.java
@@ -4,11 +4,21 @@ import sh.ball.engine.Vector3;
 
 public class ObjFrameSettings {
 
-  protected Double focalLength;
-  protected Vector3 cameraPos;
-  protected Vector3 rotation;
-  protected Double rotateSpeed;
-  protected boolean resetRotation = false;
+  public Double focalLength;
+  public Vector3 cameraPos;
+  public Vector3 baseRotation;
+  public Vector3 currentRotation;
+  public Double rotateSpeed;
+  public boolean resetRotation = false;
+
+  protected ObjFrameSettings(Double focalLength, Vector3 cameraPos, Vector3 baseRotation, Vector3 currentRotation, Double rotateSpeed, boolean resetRotation) {
+    this.focalLength = focalLength;
+    this.cameraPos = cameraPos;
+    this.baseRotation = baseRotation;
+    this.currentRotation = currentRotation;
+    this.rotateSpeed = rotateSpeed;
+    this.resetRotation = resetRotation;
+  }
 
   protected ObjFrameSettings(double focalLength) {
     this.focalLength = focalLength;
@@ -18,8 +28,8 @@ public class ObjFrameSettings {
     this.cameraPos = cameraPos;
   }
 
-  protected ObjFrameSettings(Vector3 rotation, Double rotateSpeed) {
-    this.rotation = rotation;
+  protected ObjFrameSettings(Vector3 baseRotation, Double rotateSpeed) {
+    this.baseRotation = baseRotation;
     this.rotateSpeed = rotateSpeed;
   }
 

--- a/src/main/java/sh/ball/parser/obj/ObjFrameSource.java
+++ b/src/main/java/sh/ball/parser/obj/ObjFrameSource.java
@@ -13,7 +13,8 @@ public class ObjFrameSource implements FrameSource<List<Shape>> {
   private final WorldObject object;
   private final Camera camera;
 
-  private Vector3 rotation = new Vector3(Math.PI, Math.PI, 0);
+  private Vector3 baseRotation = new Vector3(Math.PI, Math.PI, 0);
+  private Vector3 currentRotation = baseRotation;
   private Double rotateSpeed = 0.0;
   private boolean active = true;
 
@@ -24,10 +25,11 @@ public class ObjFrameSource implements FrameSource<List<Shape>> {
 
   @Override
   public List<Shape> next() {
+    currentRotation = currentRotation.add(baseRotation.scale(rotateSpeed));
     if (rotateSpeed == 0) {
-      object.setRotation(rotation);
+      object.setRotation(baseRotation);
     } else {
-      object.rotate(rotation.scale(rotateSpeed));
+      object.setRotation(currentRotation);
     }
     return camera.draw(object);
   }
@@ -57,8 +59,11 @@ public class ObjFrameSource implements FrameSource<List<Shape>> {
       if (obj.cameraPos != null && camera.getPos() != obj.cameraPos) {
         camera.setPos(obj.cameraPos);
       }
-      if (obj.rotation != null) {
-        this.rotation = obj.rotation;
+      if (obj.baseRotation != null) {
+        this.baseRotation = obj.baseRotation;
+      }
+      if (obj.currentRotation != null) {
+        this.currentRotation = obj.currentRotation;
       }
       if (obj.rotateSpeed != null) {
         this.rotateSpeed = obj.rotateSpeed;
@@ -67,5 +72,11 @@ public class ObjFrameSource implements FrameSource<List<Shape>> {
         object.resetRotation();
       }
     }
+  }
+
+  // TODO: Refactor!
+  @Override
+  public Object getFrameSettings() {
+    return ObjSettingsFactory.rotation(baseRotation, currentRotation);
   }
 }

--- a/src/main/java/sh/ball/parser/obj/ObjSettingsFactory.java
+++ b/src/main/java/sh/ball/parser/obj/ObjSettingsFactory.java
@@ -12,8 +12,12 @@ public class ObjSettingsFactory {
     return new ObjFrameSettings(cameraPos);
   }
 
-  public static ObjFrameSettings rotation(Vector3 rotation) {
-    return new ObjFrameSettings(rotation, null);
+  public static ObjFrameSettings baseRotation(Vector3 baseRotation) {
+    return new ObjFrameSettings(baseRotation, null);
+  }
+
+  public static ObjFrameSettings rotation(Vector3 baseRotation, Vector3 currentRotation) {
+    return new ObjFrameSettings(null, null, baseRotation, currentRotation, null, false);
   }
 
   public static ObjFrameSettings rotateSpeed(double rotateSpeed) {

--- a/src/main/java/sh/ball/shapes/ShapeFrameSource.java
+++ b/src/main/java/sh/ball/shapes/ShapeFrameSource.java
@@ -36,4 +36,7 @@ public class ShapeFrameSource implements FrameSource<List<Shape>> {
 
   @Override
   public void setFrameSettings(Object settings) {}
+
+  @Override
+  public Object getFrameSettings() { return null; }
 }


### PR DESCRIPTION
### Changes

- Increases `BUFFER_SIZE` in `ShapeAudioPlayer` to reduce audio glitches
- Maintain rotation information between 3D objects properly
- Draw 3D objects in a consistent order
  - They are now deterministically drawn and always sound the same