### PR TITLE
Use viewBox and width/height to correctly render SVGs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>sh.ball</groupId>
     <artifactId>osci-render</artifactId>
-    <version>1.16.3</version>
+    <version>1.16.4</version>
 
     <name>osci-render</name>
 

--- a/src/main/java/sh/ball/parser/obj/ObjFrameSource.java
+++ b/src/main/java/sh/ball/parser/obj/ObjFrameSource.java
@@ -13,7 +13,7 @@ public class ObjFrameSource implements FrameSource<List<Shape>> {
   private final WorldObject object;
   private final Camera camera;
 
-  private Vector3 baseRotation = new Vector3(Math.PI, Math.PI, 0);
+  private Vector3 baseRotation = new Vector3(2 * Math.PI, 2 * Math.PI, 0);
   private Vector3 currentRotation = baseRotation;
   private Double rotateSpeed = 0.0;
   private boolean active = true;

--- a/src/main/java/sh/ball/shapes/Shape.java
+++ b/src/main/java/sh/ball/shapes/Shape.java
@@ -88,6 +88,8 @@ public abstract class Shape {
     return translate(normalizedShapes, new Vector2(-1, -maxVector.getY() + height / 2));
   }
 
+  // TODO: Ideally this should cut off any width/height that is less than maxDim.
+  // If this is confusing, compare the output of a square viewBox vs non-square.
   public static List<Shape> normalize(List<Shape> shapes, double width, double height) {
     double maxDim = Math.max(width, height);
     List<Shape> normalizedShapes = new ArrayList<>();


### PR DESCRIPTION
### Changes

- `SVGParser` now looks at `viewBox`, `width`, and `height` attributes of the `svg` tag
  - Shapes are normalised according to this. They are scaled according to the max-absolute dimension
  - Currently ignoring `min-x` and `min-y`
- Change base rotation so that it is no longer rendered upside-down for objects

#### Before

![image](https://user-images.githubusercontent.com/38670946/146999545-b7f4be2b-aa91-4f1e-b3ec-bc16e5738f29.png)

#### After

https://user-images.githubusercontent.com/38670946/146999774-a5c16f45-c124-44d1-86fd-afea2e073d3a.mp4
