### PR TITLE
Add version to interface and improve slider usability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+- 1.24.6
+  - Effect text boxes are now editable
+  - Version number now visible in File menu
+  - You can now double-click sliders to reset their values to minimum
+
+
 - 1.24.5
   - Bug fix: MIDI CC signals can now be used to change frequency slider
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>sh.ball</groupId>
     <artifactId>osci-render</artifactId>
-    <version>1.24.5</version>
+    <version>1.24.6</version>
 
     <name>osci-render</name>
 

--- a/src/main/java/sh/ball/gui/controller/ImageController.java
+++ b/src/main/java/sh/ball/gui/controller/ImageController.java
@@ -174,12 +174,10 @@ public class ImageController implements Initializable, SubController {
     frequency.set(MidiNote.MIDDLE_C);
     frequencySlider.setOnKeyPressed(e -> {
       if (e.getCode() == KeyCode.LEFT || e.getCode() == KeyCode.RIGHT) {
-        frequency.set(Math.pow(MAX_FREQUENCY, frequencySlider.getValue()));
+        slidersUpdated();
       }
     });
-    frequencySlider.setOnMouseDragged(e ->
-      frequency.set(Math.pow(MAX_FREQUENCY, frequencySlider.getValue()))
-    );
+    frequencySlider.setOnMouseDragged(e -> slidersUpdated());
 
     volumeSlider.valueProperty().addListener((e, old, value) ->
       audioPlayer.setVolume(value.doubleValue() / 3.0)
@@ -239,7 +237,7 @@ public class ImageController implements Initializable, SubController {
     translationXTextField.setText(x.getTextContent());
     translationYTextField.setText(y.getTextContent());
 
-    frequency.set(Math.pow(MAX_FREQUENCY, frequencySlider.getValue()));
+    slidersUpdated();
 
     // For backwards compatibility we assume a default value
     Element ellipse = (Element) element.getElementsByTagName("ellipse").item(0);

--- a/src/main/java/sh/ball/gui/controller/MainController.java
+++ b/src/main/java/sh/ball/gui/controller/MainController.java
@@ -317,6 +317,12 @@ public class MainController implements Initializable, FrequencyListener, MidiLis
       }
       sliders.get(i).minProperty().addListener(e -> updateClosestChannelToZero(sliders.get(finalI)));
       sliders.get(i).maxProperty().addListener(e -> updateClosestChannelToZero(sliders.get(finalI)));
+      sliders.get(i).setOnMouseClicked(event -> {
+        if (event.getClickCount() == 2) {
+          sliders.get(finalI).setValue(sliders.get(finalI).getMin());
+        }
+        subControllers().forEach(SubController::slidersUpdated);
+      });
     }
 
     objController.setAudioProducer(producer);

--- a/src/main/resources/fxml/effectComponentGroup.fxml
+++ b/src/main/resources/fxml/effectComponentGroup.fxml
@@ -20,7 +20,7 @@
             <Insets right="5.0" />
          </HBox.margin>
       </Slider>
-      <Spinner fx:id="spinner" disable="true" prefHeight="26.0" prefWidth="66.0">
+      <Spinner fx:id="spinner" editable="true" disable="true" prefHeight="26.0" prefWidth="66.0">
          <HBox.margin>
             <Insets top="1.0" />
          </HBox.margin>

--- a/src/main/resources/fxml/main.fxml
+++ b/src/main/resources/fxml/main.fxml
@@ -19,6 +19,7 @@
      <menus>
        <Menu mnemonicParsing="false" text="File">
             <items>
+               <MenuItem disable="true" mnemonicParsing="false" text="osci-render v1.24.6" />
                <MenuItem fx:id="openProjectMenuItem" mnemonicParsing="false" text="Open Project">
                   <accelerator>
                      <KeyCodeCombination alt="UP" code="O" control="UP" meta="UP" shift="UP" shortcut="DOWN" />


### PR DESCRIPTION
- Effect text boxes are now editable
- Version number now visible in File menu
- You can now double-click sliders to reset their values to minimum