### PR TITLE
Support mono output and >2 audio outputs with controllable brightness values

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 osci-render.iml
 *.osci
 *.log
+.DS_Store
 
 # ignore temporary files
 *~

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+- 1.24.8
+  - Mono and more than 2 audio outputs supported
+  - Any audio output after the first L and R channels are used for brightness
+    - The brightness is controllable under Audio > Brightness
+    - This will only work if the audio interface being used is DC-coupled as it is a static voltage signal
+
+
 - 1.24.7
   - Double-click of slider resets value to 0 rather than min
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>sh.ball</groupId>
     <artifactId>osci-render</artifactId>
-    <version>1.24.7</version>
+    <version>1.24.8</version>
 
     <name>osci-render</name>
 

--- a/src/main/java/sh/ball/audio/AudioPlayer.java
+++ b/src/main/java/sh/ball/audio/AudioPlayer.java
@@ -42,4 +42,6 @@ public interface AudioPlayer<S> extends Runnable, MidiListener {
   List<AudioDevice> devices();
 
   AudioInputStream stopRecord();
+
+  void setBrightness(double brightness);
 }

--- a/src/main/java/sh/ball/audio/ShapeAudioPlayer.java
+++ b/src/main/java/sh/ball/audio/ShapeAudioPlayer.java
@@ -484,6 +484,11 @@ public class ShapeAudioPlayer implements AudioPlayer<List<Shape>> {
     return new AudioInputStream(new ByteArrayInputStream(input), audioFormat, framesRecorded);
   }
 
+  @Override
+  public void setBrightness(double brightness) {
+    audioEngine.setBrightness(brightness);
+  }
+
   private void updateSineEffects() {
     for (int channel = 0; channel < keyActualVolumes.length; channel++) {
       for (int key = 0; key < keyActualVolumes[channel].length; key++) {

--- a/src/main/java/sh/ball/audio/engine/AudioDevice.java
+++ b/src/main/java/sh/ball/audio/engine/AudioDevice.java
@@ -8,4 +8,6 @@ public interface AudioDevice {
   int sampleRate();
 
   AudioSample sample();
+
+  int channels();
 }

--- a/src/main/java/sh/ball/audio/engine/AudioEngine.java
+++ b/src/main/java/sh/ball/audio/engine/AudioEngine.java
@@ -17,4 +17,6 @@ public interface AudioEngine {
   AudioDevice getDefaultDevice();
 
   AudioDevice currentDevice();
+
+  void setBrightness(double brightness);
 }

--- a/src/main/java/sh/ball/audio/engine/ConglomerateAudioEngine.java
+++ b/src/main/java/sh/ball/audio/engine/ConglomerateAudioEngine.java
@@ -91,6 +91,12 @@ public class ConglomerateAudioEngine implements AudioEngine {
     return device;
   }
 
+  @Override
+  public void setBrightness(double brightness) {
+    javaEngine.setBrightness(brightness);
+    xtEngine.setBrightness(brightness);
+  }
+
   // This ensures that the channelGenerator is ALWAYS being called regardless
   // of whether the underlying AudioEngine is requesting channels as soon as they
   // are needed. This significantly improves performance of JavaAudioEngine and

--- a/src/main/java/sh/ball/audio/engine/SimpleAudioDevice.java
+++ b/src/main/java/sh/ball/audio/engine/SimpleAudioDevice.java
@@ -2,13 +2,21 @@ package sh.ball.audio.engine;
 
 import java.util.Objects;
 
-public record SimpleAudioDevice(String id, String name, int sampleRate, AudioSample sample) implements AudioDevice {
+public record SimpleAudioDevice(String id, String name, int sampleRate, AudioSample sample, int channels) implements AudioDevice {
 
   @Override
   public String toString() {
     String simplifiedName = name.replaceFirst(" \\(Shared\\)", "");
     simplifiedName = simplifiedName.replaceFirst(" \\(NVIDIA High Definition Audio\\)", "");
-    return simplifiedName + " @ " + sampleRate + "Hz, " + sample;
+    simplifiedName += " @ " + sampleRate + "Hz, " + sample + ", ";
+    if (channels == 1) {
+      simplifiedName += "mono";
+    } else if (channels == 2) {
+      simplifiedName += "stereo";
+    } else {
+      simplifiedName += channels + "outputs";
+    }
+    return simplifiedName;
   }
 
   @Override
@@ -16,11 +24,15 @@ public record SimpleAudioDevice(String id, String name, int sampleRate, AudioSam
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
     SimpleAudioDevice that = (SimpleAudioDevice) o;
-    return sampleRate == that.sampleRate && Objects.equals(id, that.id) && Objects.equals(name, that.name) && sample == that.sample;
+    return sampleRate == that.sampleRate
+      && Objects.equals(id, that.id)
+      && Objects.equals(name, that.name)
+      && sample == that.sample
+      && channels == that.channels;
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(id, name, sampleRate, sample);
+    return Objects.hash(id, name, sampleRate, sample, channels);
   }
 }

--- a/src/main/java/sh/ball/gui/controller/MainController.java
+++ b/src/main/java/sh/ball/gui/controller/MainController.java
@@ -160,6 +160,8 @@ public class MainController implements Initializable, FrequencyListener, MidiLis
   @FXML
   private ComboBox<AudioDevice> deviceComboBox;
   @FXML
+  private Slider brightnessSlider;
+  @FXML
   private CustomMenuItem recordLengthMenuItem;
   @FXML
   private CheckBox recordCheckBox;
@@ -474,6 +476,8 @@ public class MainController implements Initializable, FrequencyListener, MidiLis
       }
     });
 
+    brightnessSlider.valueProperty().addListener((e, old, brightness) -> audioPlayer.setBrightness(brightness.doubleValue()));
+
     objController.updateObjectRotateSpeed();
 
     switchAudioDevice(defaultDevice, false);
@@ -566,9 +570,14 @@ public class MainController implements Initializable, FrequencyListener, MidiLis
       }
     }
     audioPlayer.setDevice(device);
+    audioPlayer.setBrightness(brightnessSlider.getValue());
     effectsController.setAudioDevice(device);
     imageController.setAudioDevice(device);
     sampleRate = device.sampleRate();
+    // brightness is configurable for many-output audio interfaces
+    if (device.channels() > 2) {
+      brightnessSlider.setDisable(false);
+    }
     if (analyser != null) {
       analyser.stop();
     }
@@ -814,16 +823,19 @@ public class MainController implements Initializable, FrequencyListener, MidiLis
   private List<CheckBox> micCheckBoxes() {
     List<CheckBox> checkBoxes = new ArrayList<>();
     subControllers().forEach(controller -> checkBoxes.addAll(controller.micCheckBoxes()));
+    checkBoxes.add(null);
     return checkBoxes;
   }
   private List<Slider> sliders() {
     List<Slider> sliders = new ArrayList<>();
     subControllers().forEach(controller -> sliders.addAll(controller.sliders()));
+    sliders.add(brightnessSlider);
     return sliders;
   }
   private List<String> labels() {
     List<String> labels = new ArrayList<>();
     subControllers().forEach(controller -> labels.addAll(controller.labels()));
+    labels.add("brightness");
     return labels;
   }
 

--- a/src/main/resources/css/main.css
+++ b/src/main/resources/css/main.css
@@ -103,6 +103,11 @@
     -fx-padding: 0.2em;
 }
 
+.slider .axis .axis-tick-mark, .slider .axis .axis-minor-tick-mark {
+    -fx-fill: null;
+    -fx-stroke: white;
+}
+
 .check-box > .box {
     -fx-background-radius: 0;
     -fx-background-color: very_dark;

--- a/src/main/resources/fxml/main.fxml
+++ b/src/main/resources/fxml/main.fxml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
+<?import javafx.geometry.Insets?>
 <?import javafx.scene.control.CheckBox?>
 <?import javafx.scene.control.CheckMenuItem?>
 <?import javafx.scene.control.ComboBox?>
@@ -8,6 +9,7 @@
 <?import javafx.scene.control.Menu?>
 <?import javafx.scene.control.MenuBar?>
 <?import javafx.scene.control.MenuItem?>
+<?import javafx.scene.control.Slider?>
 <?import javafx.scene.control.Spinner?>
 <?import javafx.scene.control.TextField?>
 <?import javafx.scene.control.TitledPane?>
@@ -19,7 +21,7 @@
      <menus>
        <Menu mnemonicParsing="false" text="File">
             <items>
-               <MenuItem disable="true" mnemonicParsing="false" text="osci-render v1.24.7" />
+               <MenuItem disable="true" mnemonicParsing="false" text="osci-render v1.24.8" />
                <MenuItem fx:id="openProjectMenuItem" mnemonicParsing="false" text="Open Project">
                   <accelerator>
                      <KeyCodeCombination alt="UP" code="O" control="UP" meta="UP" shift="UP" shortcut="DOWN" />
@@ -44,6 +46,20 @@
                      <AnchorPane>
                         <children>
                            <ComboBox fx:id="deviceComboBox" prefHeight="26.0" prefWidth="376.0" />
+                        </children>
+                     </AnchorPane>
+                  </content>
+               </CustomMenuItem>
+               <CustomMenuItem fx:id="recordLengthMenuItem1" hideOnClick="false" mnemonicParsing="false" text="Brightness">
+                  <content>
+                     <AnchorPane>
+                        <children>
+                           <Label prefHeight="25.0" text="Brightness" textFill="WHITE" />
+                           <Slider fx:id="brightnessSlider" blockIncrement="0.01" disable="true" majorTickUnit="0.2" max="1.0" min="-1.0" prefHeight="42.0" prefWidth="253.0" showTickLabels="true" showTickMarks="true" value="1.0">
+                              <padding>
+                                 <Insets top="25.0" />
+                              </padding>
+                           </Slider>
                         </children>
                      </AnchorPane>
                   </content>


### PR DESCRIPTION
- Mono and more than 2 audio outputs supported
- Any audio output after the first L and R channels are used for brightness
  - The brightness is controllable under Audio > Brightness
  - This will only work if the audio interface being used is DC-coupled as it is a static voltage signal