### PR TITLE
Add reset rotation buttons and other small changes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>sh.ball</groupId>
     <artifactId>osci-render</artifactId>
-    <version>1.27.1</version>
+    <version>1.27.2</version>
 
     <name>osci-render</name>
 

--- a/src/main/java/sh/ball/audio/effect/EffectType.java
+++ b/src/main/java/sh/ball/audio/effect/EffectType.java
@@ -12,6 +12,7 @@ public enum EffectType {
   TRACE_MAX(-1),
   SMOOTH(100),
   DEPTH_3D(52),
+  Z_POS_3D(-1),
   ROTATE_SPEED_3D(-1),
   ROTATE_X(-1),
   ROTATE_Y(-1),

--- a/src/main/java/sh/ball/audio/effect/PerspectiveEffect.java
+++ b/src/main/java/sh/ball/audio/effect/PerspectiveEffect.java
@@ -8,8 +8,9 @@ public class PerspectiveEffect implements SettableEffect {
 
   private double zPos = 1.0;
   private Vector3 baseRotation = new Vector3(Math.PI, Math.PI, 0);
-  private Vector3 currentRotation = baseRotation;
+  private Vector3 currentRotation = new Vector3();
   private double rotateSpeed = 0.0;
+  private double effectScale = 1.0;
 
   @Override
   public Vector2 apply(int count, Vector2 vector) {
@@ -20,13 +21,17 @@ public class PerspectiveEffect implements SettableEffect {
 
     double focalLength = 1.0;
     return new Vector2(
-      vertex.x * focalLength / (vertex.z - zPos),
-      vertex.y * focalLength / (vertex.z - zPos)
+      (1 - effectScale) * vector.x + effectScale * (vertex.x * focalLength / (vertex.z - zPos)),
+      (1 - effectScale) * vector.y + effectScale * (vertex.y * focalLength / (vertex.z - zPos))
     );
   }
 
   @Override
   public void setValue(double value) {
+    this.effectScale = value;
+  }
+
+  public void setZPos(double value) {
     zPos = 1.0 + (value - 0.1) * 3;
   }
 
@@ -48,5 +53,10 @@ public class PerspectiveEffect implements SettableEffect {
 
   public void setRotationZ(double rotateZ) {
     this.baseRotation = new Vector3(baseRotation.x, baseRotation.y, rotateZ * Math.PI);
+  }
+
+  public void resetRotation() {
+    baseRotation = new Vector3();
+    currentRotation = new Vector3();
   }
 }

--- a/src/main/java/sh/ball/audio/effect/PerspectiveEffect.java
+++ b/src/main/java/sh/ball/audio/effect/PerspectiveEffect.java
@@ -57,6 +57,6 @@ public class PerspectiveEffect implements SettableEffect {
 
   public void resetRotation() {
     baseRotation = new Vector3();
-    currentRotation = new Vector3();
+    currentRotation = new Vector3(Math.PI, Math.PI, 0);
   }
 }

--- a/src/main/java/sh/ball/gui/controller/EffectsController.java
+++ b/src/main/java/sh/ball/gui/controller/EffectsController.java
@@ -226,8 +226,8 @@ public class EffectsController implements Initializable, SubController {
     });
 
     resetRotationButton.setOnAction(e -> {
-      rotateEffect.resetTheta();
       rotateSpeed.controller.slider.setValue(0);
+      rotateEffect.resetTheta();
     });
 
     resetPerspectiveRotationButton.setOnAction(e -> {

--- a/src/main/java/sh/ball/gui/controller/EffectsController.java
+++ b/src/main/java/sh/ball/gui/controller/EffectsController.java
@@ -63,6 +63,8 @@ public class EffectsController implements Initializable, SubController {
   @FXML
   private EffectComponentGroup rotateZ;
   @FXML
+  private EffectComponentGroup zPos;
+  @FXML
   private EffectComponentGroup translationScale;
   @FXML
   private EffectComponentGroup translationSpeed;
@@ -82,6 +84,10 @@ public class EffectsController implements Initializable, SubController {
   private CheckBox translateCheckBox;
   @FXML
   private Button resetTranslationButton;
+  @FXML
+  private Button resetRotationButton;
+  @FXML
+  private Button resetPerspectiveRotationButton;
 
   public EffectsController() {
     this.wobbleEffect = new WobbleEffect(DEFAULT_SAMPLE_RATE);
@@ -119,7 +125,7 @@ public class EffectsController implements Initializable, SubController {
 
     if (type == EffectType.DEPTH_3D) {
       Platform.runLater(() ->
-        List.of(rotateSpeed3D, rotateX, rotateY, rotateZ).forEach(ecg -> {
+        List.of(rotateSpeed3D, rotateX, rotateY, rotateZ, zPos).forEach(ecg -> {
           ecg.controller.slider.setDisable(!checked);
           ecg.controller.spinner.setDisable(!checked);
         })
@@ -162,6 +168,7 @@ public class EffectsController implements Initializable, SubController {
     rotateX.controller.setAnimator(new EffectAnimator(DEFAULT_SAMPLE_RATE, new ConsumerEffect((perspectiveEffect::setRotationX))));
     rotateY.controller.setAnimator(new EffectAnimator(DEFAULT_SAMPLE_RATE, new ConsumerEffect((perspectiveEffect::setRotationY))));
     rotateZ.controller.setAnimator(new EffectAnimator(DEFAULT_SAMPLE_RATE, new ConsumerEffect((perspectiveEffect::setRotationZ))));
+    zPos.controller.setAnimator(new EffectAnimator(DEFAULT_SAMPLE_RATE, new ConsumerEffect((perspectiveEffect::setZPos))));
     traceMin.controller.setAnimator(new EffectAnimator(DEFAULT_SAMPLE_RATE, new ConsumerEffect(audioPlayer::setTraceMin)));
     traceMax.controller.setAnimator(new EffectAnimator(DEFAULT_SAMPLE_RATE, new ConsumerEffect(audioPlayer::setTraceMax)));
     vectorCancelling.controller.setAnimator(new EffectAnimator(DEFAULT_SAMPLE_RATE, new VectorCancellingEffect()));
@@ -213,9 +220,22 @@ public class EffectsController implements Initializable, SubController {
 
     translateEllipseCheckBox.selectedProperty().addListener((e, old, ellipse) -> translateEffect.setEllipse(ellipse));
 
-    List.of(rotateSpeed3D, rotateX, rotateY, rotateZ).forEach(ecg -> {
+    List.of(rotateSpeed3D, rotateX, rotateY, rotateZ, zPos).forEach(ecg -> {
       ecg.controller.slider.setDisable(true);
       ecg.controller.spinner.setDisable(true);
+    });
+
+    resetRotationButton.setOnAction(e -> {
+      rotateEffect.resetTheta();
+      rotateSpeed.controller.slider.setValue(0);
+    });
+
+    resetPerspectiveRotationButton.setOnAction(e -> {
+      rotateX.controller.slider.setValue(0);
+      rotateY.controller.slider.setValue(0);
+      rotateZ.controller.slider.setValue(0);
+      rotateSpeed3D.controller.slider.setValue(0);
+      perspectiveEffect.resetRotation();
     });
   }
 
@@ -230,6 +250,7 @@ public class EffectsController implements Initializable, SubController {
       traceMin,
       traceMax,
       rotateSpeed3D,
+      zPos,
       rotateX,
       rotateY,
       rotateZ,

--- a/src/main/java/sh/ball/gui/controller/MainController.java
+++ b/src/main/java/sh/ball/gui/controller/MainController.java
@@ -1458,6 +1458,8 @@ public class MainController implements Initializable, FrequencyListener, MidiLis
       }
     }
 
+    updateRecentFiles();
+
     luaController.updateLuaVariables();
 
     objectServer = new ObjectServer(this::enableObjectServerRendering, this::disableObjectServerRendering);

--- a/src/main/resources/CHANGELOG.md
+++ b/src/main/resources/CHANGELOG.md
@@ -1,6 +1,7 @@
 - 1.27.2
   - Add reset 2D rotation button to effects
   - Add reset 3D perspective rotation button to effects
+  - Correctly show recent files under File menu when starting a new project
   - Minor changes to perspective effect
     - Added a new '3D Distance' effect that functions the same as the '3D Perspective' effect in the previous version
     - Changed the '3D Perspective' effect so that a value of 0 applies no change to the image

--- a/src/main/resources/CHANGELOG.md
+++ b/src/main/resources/CHANGELOG.md
@@ -1,3 +1,14 @@
+- 1.27.2
+  - Add reset 2D rotation button to effects
+  - Add reset 3D perspective rotation button to effects
+  - Minor changes to perspective effect
+    - Added a new '3D Distance' effect that functions the same as the '3D Perspective' effect in the previous version
+    - Changed the '3D Perspective' effect so that a value of 0 applies no change to the image
+      - This makes it in-line with most other effects, where a value of 0 doesn't affect the image
+      - Default value is 1.0 which has the depth effect fully applied
+      - Values between 0.0 and 1.0 mix the effect to make a cool image!
+
+
 - 1.27.1
   - Improve performance of project select screen by only starting main osci-render program after a project is opened/created
   - Fix bug where images could be drawn so slowly that the frame would never finish drawing

--- a/src/main/resources/fxml/effects.fxml
+++ b/src/main/resources/fxml/effects.fxml
@@ -11,9 +11,9 @@
 <?import javafx.scene.layout.VBox?>
 <?import sh.ball.gui.components.EffectComponentGroup?>
 
-<ScrollPane hbarPolicy="NEVER" prefHeight="954.0" prefWidth="608.0" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1" fx:controller="sh.ball.gui.controller.EffectsController">
+<ScrollPane hbarPolicy="NEVER" prefHeight="1065.0" prefWidth="608.0" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1" fx:controller="sh.ball.gui.controller.EffectsController">
    <content>
-      <AnchorPane minHeight="0.0" minWidth="0.0" prefHeight="951.0" prefWidth="606.0">
+      <AnchorPane minHeight="0.0" minWidth="0.0" prefHeight="1049.0" prefWidth="606.0">
           <children>
             <VBox>
                <children>
@@ -79,11 +79,22 @@
                      </padding>
                   </Separator>
                    <EffectComponentGroup fx:id="rotateSpeed" increment="0.05" label="rotateSpeed" majorTickUnit="1.0" max="10.0" min="0.0" name="2D Rotate speed" type="ROTATE" value="0.0" />
-                  <EffectComponentGroup fx:id="depthScale" increment="0.005" label="depthScale" majorTickUnit="0.1" max="1.0" min="0.0" name="3D Depth" type="DEPTH_3D" value="0.1" />
+                  <AnchorPane prefHeight="34.0" prefWidth="602.0">
+                     <children>
+                        <Button fx:id="resetRotationButton" layoutX="245.0" layoutY="1.0" mnemonicParsing="false" text="Reset 2D Rotation" />
+                     </children>
+                  </AnchorPane>
+                  <EffectComponentGroup fx:id="depthScale" increment="0.005" label="depthScale" majorTickUnit="0.1" max="1.0" min="0.0" name="3D Perspective" type="DEPTH_3D" value="1.0" />
+                  <EffectComponentGroup fx:id="zPos" alwaysEnabled="true" increment="0.005" label="zPos" max="1.0" name="3D Distance" type="Z_POS_3D" value="0.1" />
                   <EffectComponentGroup fx:id="rotateSpeed3D" alwaysEnabled="true" increment="0.005" label="rotateSpeed3d" majorTickUnit="0.2" max="1.0" min="-1.0" name="3D Rotate speed" type="ROTATE_SPEED_3D" value="0.0" />
                   <EffectComponentGroup fx:id="rotateX" alwaysEnabled="true" increment="0.01" label="imageRotateX" majorTickUnit="0.2" max="1.0" min="-1.0" name="Rotate x" type="ROTATE_X" value="1.0" />
                   <EffectComponentGroup fx:id="rotateY" alwaysEnabled="true" increment="0.01" label="imageRotateY" majorTickUnit="0.2" max="1.0" min="-1.0" name="Rotate y" type="ROTATE_Y" value="1.0" />
                   <EffectComponentGroup fx:id="rotateZ" alwaysEnabled="true" increment="0.01" label="imageRotateZ" majorTickUnit="0.2" max="1.0" min="-1.0" name="Rotate z" type="ROTATE_Z" value="0.0" />
+                  <AnchorPane prefHeight="34.0" prefWidth="602.0">
+                     <children>
+                        <Button fx:id="resetPerspectiveRotationButton" layoutX="245.0" layoutY="1.0" mnemonicParsing="false" text="Reset 3D Rotation" />
+                     </children>
+                  </AnchorPane>
                   <Label alignment="CENTER" prefWidth="601.0" text="Other" textAlignment="JUSTIFY">
                      <padding>
                         <Insets bottom="5.0" />

--- a/src/main/resources/fxml/projectSelect.fxml
+++ b/src/main/resources/fxml/projectSelect.fxml
@@ -27,7 +27,7 @@
          <Button fx:id="newProjectButton" layoutX="222.0" layoutY="562.0" mnemonicParsing="false" prefHeight="40.0" prefWidth="131.0" text="Start new project" />
          <CheckBox fx:id="startMutedCheckBox" layoutX="240.0" layoutY="623.0" mnemonicParsing="false" text="Start muted" />
          <Label layoutX="188.0" layoutY="247.0" styleClass="title" text="Recently opened projects" />
-         <Label layoutX="14.0" layoutY="700.0" text="v1.27.1" />
+         <Label layoutX="14.0" layoutY="700.0" text="v1.27.2" />
          <Label layoutX="727.0" layoutY="20.0" styleClass="title" text="Changelog" />
          <AnchorPane layoutX="582.0" layoutY="65.0" prefHeight="200.0" prefWidth="380.0">
             <children>


### PR DESCRIPTION
- Add reset 2D rotation button to effects
- Add reset 3D perspective rotation button to effects
- Correctly show recent files under File menu when starting a new project
- Minor changes to perspective effect
  - Added a new '3D Distance' effect that functions the same as the '3D Perspective' effect in the previous version
  - Changed the '3D Perspective' effect so that a value of 0 applies no change to the image
    - This makes it in-line with most other effects, where a value of 0 doesn't affect the image
    - Default value is 1.0 which has the depth effect fully applied
    - Values between 0.0 and 1.0 mix the effect to make a cool image!