### PR TITLE
Make Line.getLength() work (in 2 fewer lines)

### DIFF
--- a/src/main/java/sh/ball/shapes/Line.java
+++ b/src/main/java/sh/ball/shapes/Line.java
@@ -35,10 +35,8 @@ public final class Line extends Shape {
       // Euclidean distance approximation based on octagonal boundary
       double dx = Math.abs(b.x - a.x);
       double dy = Math.abs(b.y - a.y);
-      double min = dy <= dx ? dx : dy;
-      double max = dy > dx ? dy : dx;
 
-      length = 0.41 * min + 0.941246 * max;
+      length = 0.41 * Math.min(dx, dy) + 0.941246 * Math.max(dx, dy);
     }
     return length;
   }


### PR DESCRIPTION
double min = dy <= dx ? dx : dy;
This was previously wrong (calculated the maximum instead of minimum) and also inefficient

double max = dy > dx ? dy : dx;
This was previously right, but was still inefficient

Last small bugfix for now, I thought I had more, but since I'm going through every single file there will be more eventually. Almost 100%. However, your code is really well written and understandable, so I've been porting everything to C++ smoothly. Should be a few more days of work, but not a few weeks.