### PR TITLE
Volume visualiser + Java 19

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,10 +11,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 17
+    - name: Set up JDK 19
       uses: actions/setup-java@v2
       with:
-        java-version: '17'
+        java-version: '19'
         distribution: 'adopt'
     - name: Build with Maven
       run: |
@@ -44,10 +44,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK 17
+      - name: Set up JDK 19
         uses: actions/setup-java@v2
         with:
-          java-version: '17'
+          java-version: '19'
           distribution: 'adopt'
       - name: Build with Maven
         run: |
@@ -74,10 +74,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK 17
+      - name: Set up JDK 19
         uses: actions/setup-java@v2
         with:
-          java-version: '17'
+          java-version: '19'
           distribution: 'adopt'
       - name: Build with Maven
         run: |

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ To uninstall, use Windows control panel, as you would expect.
 - Download the latest `osci-render-os-VERSION.jar` from [Releases](https://github.com/jameshball/osci-render/releases)
   - Download the version that is relevant to your OS, otherwise the program will not open
   - i.e. `osci-render-win-VERSION.jar` for Windows and `osci-render-unix-VERSION.jar` for Linux
-- Download and install [Java 17 or later](https://www.oracle.com/java/technologies/downloads/)
+- Download and install [Java 19 or later](https://www.oracle.com/java/technologies/downloads/)
 - Run the following command from your terminal to run the `.jar`, substituting the correct path to your `.jar` file 
 - `java "-Dfile.encoding=UTF8" -jar "PATH/TO/osci-render-os-VERSION.jar"`
 - Start rendering!
@@ -177,7 +177,7 @@ To uninstall, use Windows control panel, as you would expect.
 
 I am using Maven for dependency management and to package the program. Doing the following will setup the project. I highly recommend using IntelliJ.
 
-- Download and install [Java 17 or later](https://www.oracle.com/java/technologies/downloads/)
+- Download and install [Java 19 or later](https://www.oracle.com/java/technologies/downloads/)
 - Run `git clone git@github.com:jameshball/osci-render.git`
 - Open the project in IntelliJ
 - I use [SceneBuilder](https://gluonhq.com/products/scene-builder/) to edit the GUI

--- a/pom.xml
+++ b/pom.xml
@@ -12,8 +12,8 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.release>17</maven.compiler.release>
-        <javafx.version>17.0.1</javafx.version>
+        <maven.compiler.release>19</maven.compiler.release>
+        <javafx.version>19</javafx.version>
         <appMainClass>sh.ball.gui.Launcher</appMainClass>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>sh.ball</groupId>
     <artifactId>osci-render</artifactId>
-    <version>1.29.0</version>
+    <version>1.30.0</version>
 
     <name>osci-render</name>
 

--- a/src/main/java/sh/ball/audio/AudioPlayer.java
+++ b/src/main/java/sh/ball/audio/AudioPlayer.java
@@ -32,6 +32,8 @@ public interface AudioPlayer<S> extends Runnable, MidiListener {
 
   void read(byte[] buffer) throws InterruptedException;
 
+  void read(double[] buffer) throws InterruptedException;
+
   void startRecord();
 
   void setDevice(AudioDevice device);
@@ -45,4 +47,6 @@ public interface AudioPlayer<S> extends Runnable, MidiListener {
   AudioInputStream stopRecord();
 
   void setBrightness(double brightness);
+
+  void setThreshold(double doubleValue);
 }

--- a/src/main/java/sh/ball/gui/controller/EffectsController.java
+++ b/src/main/java/sh/ball/gui/controller/EffectsController.java
@@ -87,8 +87,6 @@ public class EffectsController implements Initializable, SubController {
   @FXML
   private EffectComponentGroup rotateSpeed;
   @FXML
-  private EffectComponentGroup volume;
-  @FXML
   private EffectComponentGroup backingMidi;
   @FXML
   private TextField translationXTextField;
@@ -194,7 +192,6 @@ public class EffectsController implements Initializable, SubController {
     translationScale.setAnimator(new EffectAnimator(DEFAULT_SAMPLE_RATE, translateEffect));
     translationSpeed.setAnimator(new EffectAnimator(DEFAULT_SAMPLE_RATE, new ConsumerEffect(translateEffect::setSpeed)));
     rotateSpeed.setAnimator(new EffectAnimator(DEFAULT_SAMPLE_RATE, rotateEffect));
-    volume.setAnimator(new EffectAnimator(DEFAULT_SAMPLE_RATE, new ConsumerEffect((value) -> audioPlayer.setVolume(value / 3.0))));
     backingMidi.setAnimator(new EffectAnimator(DEFAULT_SAMPLE_RATE, new ConsumerEffect(audioPlayer::setBackingMidiVolume)));
 
     effects().forEach(effect -> {
@@ -287,7 +284,6 @@ public class EffectsController implements Initializable, SubController {
       translationScale,
       translationSpeed,
       rotateSpeed,
-      volume,
       backingMidi
     );
   }
@@ -413,10 +409,6 @@ public class EffectsController implements Initializable, SubController {
     translationYTextField.setText(MainController.FORMAT.format(translation.getY()));
   }
 
-  public void setTranslationIncrement(double increment) {
-    this.scrollDelta = increment;
-  }
-
   // changes the sinusoidal translation of the image rendered
   private void updateTranslation() {
     translateEffect.setTranslation(new Vector2(
@@ -425,17 +417,11 @@ public class EffectsController implements Initializable, SubController {
     ));
   }
 
-
-
   public boolean mouseTranslate() {
     return translateCheckBox.isSelected();
   }
 
   public void disableMouseTranslate() {
     translateCheckBox.setSelected(false);
-  }
-
-  public void setVolume(double volumeValue) {
-    volume.setValue(volumeValue);
   }
 }

--- a/src/main/java/sh/ball/gui/controller/MainController.java
+++ b/src/main/java/sh/ball/gui/controller/MainController.java
@@ -140,6 +140,8 @@ public class MainController implements Initializable, FrequencyListener, MidiLis
   @FXML
   private GeneralController generalController;
   @FXML
+  private VolumeController volumeController;
+  @FXML
   private TitledPane objTitledPane;
   @FXML
   private TitledPane luaTitledPane;
@@ -213,7 +215,7 @@ public class MainController implements Initializable, FrequencyListener, MidiLis
   }
 
   private List<SubController> subControllers() {
-    return List.of(effectsController, objController, imageController, generalController, luaController);
+    return List.of(effectsController, objController, imageController, generalController, luaController, volumeController);
   }
 
   private void updateSliderUnits(Slider slider) {
@@ -1108,7 +1110,10 @@ public class MainController implements Initializable, FrequencyListener, MidiLis
       NodeList nodes = root.getElementsByTagName(labels.get(i));
       if (nodes.getLength() > 0) {
         String value = nodes.item(0).getTextContent();
-        micSelected.get(i).setValue(Boolean.parseBoolean(value));
+        BooleanProperty selected = micSelected.get(i);
+        if (selected != null) {
+          selected.setValue(Boolean.parseBoolean(value));
+        }
       }
     }
   }
@@ -1504,7 +1509,7 @@ public class MainController implements Initializable, FrequencyListener, MidiLis
   }
 
   public void setVolume(double volume) {
-    effectsController.setVolume(volume);
+    volumeController.setVolume(volume);
   }
 
   public void initialiseAudioEngine() throws Exception {

--- a/src/main/java/sh/ball/gui/controller/VolumeController.java
+++ b/src/main/java/sh/ball/gui/controller/VolumeController.java
@@ -1,0 +1,178 @@
+package sh.ball.gui.controller;
+
+import com.sun.javafx.geom.RoundRectangle2D;
+import javafx.application.Platform;
+import javafx.beans.property.BooleanProperty;
+import javafx.fxml.FXML;
+import javafx.fxml.Initializable;
+import javafx.scene.canvas.Canvas;
+import javafx.scene.control.Slider;
+import javafx.scene.image.PixelFormat;
+import javafx.scene.image.PixelWriter;
+import javafx.scene.image.WritablePixelFormat;
+import javafx.scene.shape.Circle;
+import javafx.scene.shape.Rectangle;
+import javafx.scene.shape.SVGPath;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import sh.ball.gui.components.EffectComponentGroup;
+
+import java.net.URL;
+import java.nio.ByteBuffer;
+import java.util.*;
+import java.util.logging.Level;
+
+import static sh.ball.gui.Gui.audioPlayer;
+import static sh.ball.gui.Gui.logger;
+
+public class VolumeController implements Initializable, SubController {
+  @FXML
+  private Slider volumeSlider;
+  @FXML
+  private Slider thresholdSlider;
+  @FXML
+  private Canvas volumeCanvas;
+
+  public VolumeController() {}
+
+  @Override
+  public void initialize(URL url, ResourceBundle resourceBundle) {
+    volumeSlider.valueProperty().addListener((o, old, volume) -> audioPlayer.setVolume(volume.doubleValue() / 3));
+    thresholdSlider.valueProperty().addListener((o, old, threshold) -> audioPlayer.setThreshold(threshold.doubleValue()));
+
+    PixelWriter pixelWriter = volumeCanvas.getGraphicsContext2D().getPixelWriter();
+    WritablePixelFormat<ByteBuffer> byteBgraInstance = PixelFormat.getByteBgraPreInstance();
+
+    int width = (int) volumeCanvas.widthProperty().get();
+    int height = (int) volumeCanvas.heightProperty().get();
+
+    byte[] pixels = new byte[width * height * 4];
+    for (int i = 0; i < pixels.length; i += 4) {
+      pixels[i] = (byte) 0xFF;
+      pixels[i + 1] = (byte) 0xFF;
+      pixels[i + 2] = (byte) 0xFF;
+      pixels[i + 3] = (byte) 0xFF;
+    }
+    pixelWriter.setPixels(0, 0, width, height, byteBgraInstance, pixels, 0, width * 4);
+
+    double[] buf = new double[2 << 11];
+    double[] leftVolumes = new double[2 << 5];
+    double[] rightVolumes = new double[2 << 5];
+
+    new Thread(() -> {
+      double avgLeftVolume = 0;
+      double avgRightVolume = 0;
+
+      while (true) {
+        try {
+          audioPlayer.read(buf);
+        } catch (InterruptedException e) {
+          logger.log(Level.SEVERE, e.getMessage(), e);
+        }
+
+        double leftVolume = 0;
+        double rightVolume = 0;
+
+        for (int i = 0; i < buf.length; i += 2) {
+          leftVolume += buf[i] * buf[i];
+          rightVolume += buf[i + 1] * buf[i + 1];
+        }
+        // root-mean-square
+        leftVolume = Math.sqrt(leftVolume / (buf.length / 2.0));
+        rightVolume = Math.sqrt(rightVolume / (buf.length / 2.0));
+
+        avgLeftVolume = avgLeftVolume - leftVolumes[0] / leftVolumes.length + leftVolume / leftVolumes.length;
+        System.arraycopy(leftVolumes, 1, leftVolumes, 0, leftVolumes.length - 1);
+        leftVolumes[leftVolumes.length - 1] = leftVolume;
+
+        avgRightVolume = avgRightVolume - rightVolumes[0] / rightVolumes.length + rightVolume / rightVolumes.length;
+        System.arraycopy(rightVolumes, 1, rightVolumes, 0, rightVolumes.length - 1);
+        rightVolumes[rightVolumes.length - 1] = rightVolume;
+
+        double leftThreshold = height - leftVolume * height - 1;
+        double rightThreshold = height - rightVolume * height - 1;
+
+        double leftBar = height - avgLeftVolume * height - 1;
+        double rightBar = height - avgRightVolume * height - 1;
+        double barWidth = 2;
+
+        double threshold = height - thresholdSlider.getValue() * height - 1;
+
+        for (int i = 0; i < pixels.length; i += 4) {
+          int pixelNum = i / 4;
+          int x = pixelNum % width;
+          int y = pixelNum / width;
+
+          boolean drawGreen = x < width / 2 && y > leftThreshold || x >= width / 2 && y > rightThreshold;
+          boolean drawBar = x < width / 2 && y >= leftBar - barWidth && y <= leftBar + barWidth || x >= width / 2 && y >= rightBar - barWidth && y <= rightBar + barWidth;
+          boolean drawThreshold = y >= threshold - barWidth && y <= threshold + barWidth;
+
+          byte r = (byte) 0xFF;
+          byte g = (byte) 0xFF;
+          byte b = (byte) 0xFF;
+          byte a = (byte) 0xFF;
+
+          if (drawBar || drawThreshold) {
+            r = (byte) 0x00;
+            g = (byte) 0x00;
+            b = (byte) 0x00;
+          } else if (drawGreen) {
+            r = (byte) (0xFF - 0xFF * ((double) y / height));
+            g = (byte) (0xFF * ((double) y / height));
+            b = (byte) 0x00;
+          }
+
+          pixels[i] = b;
+          pixels[i + 1] = g;
+          pixels[i + 2] = r;
+          pixels[i + 3] = a;
+        }
+
+        Platform.runLater(() -> pixelWriter.setPixels(0, 0, width, height, byteBgraInstance, pixels, 0, width * 4));
+      }
+    }).start();
+  }
+
+  @Override
+  public Map<SVGPath, Slider> getMidiButtonMap() {
+    return Map.of();
+  }
+
+  @Override
+  public List<BooleanProperty> micSelected() {
+    List<BooleanProperty> micSelected = new ArrayList<>();
+    micSelected.add(null);
+    micSelected.add(null);
+    return micSelected;
+  }
+
+  @Override
+  public List<Slider> sliders() {
+    return List.of(volumeSlider, thresholdSlider);
+  }
+
+  @Override
+  public List<String> labels() {
+    return List.of("volume", "threshold");
+  }
+
+  @Override
+  public List<EffectComponentGroup> effects() {
+    return List.of();
+  }
+
+  @Override
+  public List<Element> save(Document document) {
+    return List.of(document.createElement("null"));
+  }
+
+  @Override
+  public void load(Element root) {}
+
+  @Override
+  public void micNotAvailable() {}
+
+  public void setVolume(double volume) {
+    volumeSlider.setValue(volume);
+  }
+}

--- a/src/main/resources/CHANGELOG.md
+++ b/src/main/resources/CHANGELOG.md
@@ -1,3 +1,15 @@
+- 1.30.0
+  - Updated osci-render to Java 19 (please report any new issues you think could be related to this!)
+  - Added volume slider on right side of main interface
+    - This replaces the volume scale slider under audio effects
+    - The slider has a volume visualiser that shows the current volume in the left and right audio channels
+    - It also shows the average volume
+    - There is also another slider that points to the volume slider that controls the hard clipping point of the audio
+      - The hard clipping point is the point at which the audio is clipped to the maximum volume
+      - Any samples above this point are set to this point
+      - By default, this is set to 1 meaning that any values less than -1 or greater than 1 are set to -1 or 1 respectively
+
+
 - 1.29.0
   - Updated the project select interface and main interface to be resizable
   - This means you can make osci-render full screen now

--- a/src/main/resources/css/main.css
+++ b/src/main/resources/css/main.css
@@ -113,6 +113,22 @@
     -fx-padding: 0.2em;
 }
 
+/*.volumeSlider > .thumb {*/
+/*    -fx-shape: "M460,265.87 1,265.87 1,0.866 460,0.866z";*/
+/*}*/
+
+.volumeSlider > .track {
+    -fx-background-color: transparent;
+}
+
+.thresholdSlider > .thumb {
+    -fx-shape: "M460,530.874 1,265.87 460,0.866z";
+}
+
+.thresholdSlider > .track {
+    -fx-background-color: transparent;
+}
+
 .slider .axis .axis-tick-mark, .slider .axis .axis-minor-tick-mark {
     -fx-fill: null;
     -fx-stroke: white;

--- a/src/main/resources/fxml/effects.fxml
+++ b/src/main/resources/fxml/effects.fxml
@@ -13,7 +13,6 @@
 <?import javafx.scene.shape.SVGPath?>
 <?import sh.ball.gui.components.EffectComponentGroup?>
 
-
 <ScrollPane fitToHeight="true" fitToWidth="true" hbarPolicy="NEVER" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1" fx:controller="sh.ball.gui.controller.EffectsController">
    <content>
       <FlowPane prefHeight="1094.0" prefWidth="603.0" prefWrapLength="100.0" rowValignment="BASELINE">
@@ -70,7 +69,6 @@
                   </AnchorPane>
                    <EffectComponentGroup fx:id="translationScale" alwaysEnabled="true" increment="0.05" label="translationScale" majorTickUnit="1.0" max="10.0" min="0.0" name="Translation scale" type="TRANSLATE" value="1.0" />
                    <EffectComponentGroup fx:id="translationSpeed" alwaysEnabled="true" increment="0.05" label="translationSpeed" majorTickUnit="1.0" max="10.0" min="0.0" name="Translation speed" type="TRANSLATE_SPEED" value="1.0" />
-                   <EffectComponentGroup fx:id="volume" alwaysEnabled="true" increment="0.05" label="volume" majorTickUnit="1.0" max="10.0" min="0.0" name="Master volume" type="SCALE" value="3.0" />
                    <EffectComponentGroup fx:id="backingMidi" alwaysEnabled="true" increment="0.005" label="visibility" majorTickUnit="0.1" max="1.0" min="0.0" name="MIDI volume" type="VISIBILITY" value="0.25" />
                </children>
             </VBox>

--- a/src/main/resources/fxml/main.fxml
+++ b/src/main/resources/fxml/main.fxml
@@ -19,7 +19,7 @@
 <?import javafx.scene.layout.HBox?>
 <?import javafx.scene.layout.VBox?>
 
-<AnchorPane maxHeight="752.0" maxWidth="1046.0" minHeight="752.0" minWidth="1046.0" prefHeight="752.0" prefWidth="1046.0" stylesheets="@../css/main.css" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1" fx:controller="sh.ball.gui.controller.MainController">
+<AnchorPane maxHeight="752.0" maxWidth="1105.0" minHeight="752.0" minWidth="1046.0" prefHeight="752.0" prefWidth="1096.0" stylesheets="@../css/main.css" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1" fx:controller="sh.ball.gui.controller.MainController">
    <MenuBar prefHeight="27.0" prefWidth="1046.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
      <menus>
        <Menu mnemonicParsing="false" text="File">
@@ -220,7 +220,7 @@
          </Menu>
      </menus>
    </MenuBar>
-   <AnchorPane fx:id="frequencyPane" prefHeight="53.0" prefWidth="610.0" styleClass="darkPane" AnchorPane.bottomAnchor="7.0" AnchorPane.leftAnchor="429.0" AnchorPane.rightAnchor="7.0">
+   <AnchorPane fx:id="frequencyPane" prefHeight="53.0" prefWidth="610.0" styleClass="darkPane" AnchorPane.bottomAnchor="7.0" AnchorPane.leftAnchor="429.0" AnchorPane.rightAnchor="60.0">
       <children>
          <HBox alignment="CENTER" prefHeight="53.0" prefWidth="610.0" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
             <children>
@@ -229,7 +229,7 @@
          </HBox>
       </children>
    </AnchorPane>
-   <TitledPane animated="false" collapsible="false" layoutX="429.0" layoutY="33.0" prefHeight="652.0" prefWidth="610.0" text="Audio Effects" AnchorPane.bottomAnchor="67.0" AnchorPane.leftAnchor="429.0" AnchorPane.rightAnchor="7.0" AnchorPane.topAnchor="33.0">
+   <TitledPane animated="false" collapsible="false" layoutX="429.0" layoutY="33.0" prefHeight="652.0" prefWidth="610.0" text="Audio Effects" AnchorPane.bottomAnchor="67.0" AnchorPane.leftAnchor="429.0" AnchorPane.rightAnchor="60.0" AnchorPane.topAnchor="33.0">
       <fx:include fx:id="effects" source="effects.fxml" />
    </TitledPane>
    <VBox alignment="CENTER" layoutX="7.0" layoutY="-91.0" prefHeight="836.0" prefWidth="416.0" spacing="7.0" AnchorPane.bottomAnchor="7.0" AnchorPane.leftAnchor="7.0" AnchorPane.topAnchor="33.0">
@@ -249,4 +249,13 @@
          </AnchorPane>
       </children>
    </VBox>
+    <AnchorPane fx:id="volumePane" layoutX="10.0" layoutY="10.0" minWidth="45.0" prefHeight="712.0" prefWidth="0.0" styleClass="darkPane" AnchorPane.bottomAnchor="7.0" AnchorPane.rightAnchor="7.0" AnchorPane.topAnchor="33.0">
+      <children>
+         <VBox alignment="CENTER" prefHeight="712.0" prefWidth="45.0" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
+            <children>
+                  <fx:include fx:id="volume" source="volume.fxml" />
+            </children>
+         </VBox>
+      </children>
+    </AnchorPane>
 </AnchorPane>

--- a/src/main/resources/fxml/projectSelect.fxml
+++ b/src/main/resources/fxml/projectSelect.fxml
@@ -43,7 +43,7 @@
                      <CheckBox fx:id="startMutedCheckBox" mnemonicParsing="false" text="Start muted" />
                      <HBox alignment="CENTER" spacing="20.0">
                         <children>
-                           <Label minWidth="42.0" prefHeight="18.0" prefWidth="42.0" text="v1.29.0" />
+                           <Label minWidth="42.0" prefHeight="18.0" prefWidth="42.0" text="v1.30.0" />
                            <Label prefHeight="54.0" prefWidth="379.0" text="Email me at james@ball.sh or create an issue on GitHub for feature suggestions, issues, or opportunites I might be interested in!" textAlignment="CENTER" wrapText="true" />
                            <Button fx:id="logButton" minWidth="102.0" mnemonicParsing="false" prefWidth="102.0" text="Open log folder" />
                         </children>

--- a/src/main/resources/fxml/projectSelect.fxml
+++ b/src/main/resources/fxml/projectSelect.fxml
@@ -13,7 +13,7 @@
 <?import javafx.scene.layout.VBox?>
 <?import javafx.scene.web.WebView?>
 
-<AnchorPane prefHeight="752.0" prefWidth="1046.0" stylesheets="@../css/main.css" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1" fx:controller="sh.ball.gui.controller.ProjectSelectController">
+<AnchorPane prefHeight="752.0" prefWidth="1096.0" stylesheets="@../css/main.css" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1" fx:controller="sh.ball.gui.controller.ProjectSelectController">
    <AnchorPane layoutX="11.0" layoutY="12.0" prefHeight="727.0" prefWidth="1023.0" styleClass="darkPane" AnchorPane.bottomAnchor="12.0" AnchorPane.leftAnchor="12.0" AnchorPane.rightAnchor="12.0" AnchorPane.topAnchor="12.0">
       <children>
          <HBox alignment="TOP_CENTER" layoutX="-3.0" prefHeight="693.0" prefWidth="992.0" spacing="20.0" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="15.0" AnchorPane.rightAnchor="15.0" AnchorPane.topAnchor="0.0">

--- a/src/main/resources/fxml/volume.fxml
+++ b/src/main/resources/fxml/volume.fxml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.geometry.Insets?>
+<?import javafx.scene.canvas.Canvas?>
+<?import javafx.scene.control.Slider?>
+<?import javafx.scene.layout.HBox?>
+<?import javafx.scene.layout.StackPane?>
+<?import javafx.scene.layout.VBox?>
+<?import javafx.scene.shape.SVGPath?>
+
+
+<HBox prefHeight="379.0" prefWidth="37.0" stylesheets="@../css/main.css" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1" fx:controller="sh.ball.gui.controller.VolumeController">
+   <children>
+      <VBox alignment="CENTER" spacing="5.0">
+         <children>
+            <SVGPath content="M14,3.23V5.29C16.89,6.15 19,8.83 19,12C19,15.17 16.89,17.84 14,18.7V20.77C18,19.86 21,16.28 21,12C21,7.72 18,4.14 14,3.23M16.5,12C16.5,10.23 15.5,8.71 14,7.97V16C15.5,15.29 16.5,13.76 16.5,12M3,9V15H7L12,20V4L7,9H3Z" fill="WHITE" scaleX="0.8" scaleY="0.8" />
+            <StackPane maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="378.0" prefWidth="24.0">
+               <children>
+                  <Canvas fx:id="volumeCanvas" height="365.0" styleClass="volumeCanvas" width="14.0" />
+                  <Slider fx:id="volumeSlider" blockIncrement="0.05" majorTickUnit="1.0" max="6.0" orientation="VERTICAL" prefWidth="14.0" styleClass="volumeSlider" value="6.0" />
+               </children>
+            </StackPane>
+         </children>
+      </VBox>
+      <VBox spacing="5.0">
+         <HBox.margin>
+            <Insets left="-2.0" />
+         </HBox.margin>
+         <children>
+            <SVGPath content="M18.5,2.27L5,10.14L18.5,18L19.5,16.27L8.97,10.14L19.5,4L18.5,2.27M5,20V22H20V20H5Z" fill="WHITE" scaleX="0.8" scaleY="0.8">
+               <VBox.margin>
+                  <Insets top="-2.0" />
+               </VBox.margin>
+            </SVGPath>
+            <Slider fx:id="thresholdSlider" blockIncrement="0.005" majorTickUnit="1.0" max="1.0" orientation="VERTICAL" prefHeight="377.0" prefWidth="14.0" styleClass="thresholdSlider" value="1.0">
+               <VBox.margin>
+                  <Insets top="-2.0" />
+               </VBox.margin>
+            </Slider>
+         </children>
+      </VBox>
+   </children>
+</HBox>

--- a/src/main/resources/fxml/volume.fxml
+++ b/src/main/resources/fxml/volume.fxml
@@ -17,7 +17,7 @@
             <StackPane maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="378.0" prefWidth="24.0">
                <children>
                   <Canvas fx:id="volumeCanvas" height="365.0" styleClass="volumeCanvas" width="14.0" />
-                  <Slider fx:id="volumeSlider" blockIncrement="0.05" majorTickUnit="1.0" max="6.0" orientation="VERTICAL" prefWidth="14.0" styleClass="volumeSlider" value="6.0" />
+                  <Slider fx:id="volumeSlider" blockIncrement="0.05" majorTickUnit="1.0" max="6.0" orientation="VERTICAL" prefWidth="14.0" styleClass="volumeSlider" value="3.0" />
                </children>
             </StackPane>
          </children>


### PR DESCRIPTION
- Updated osci-render to Java 19 (please report any new issues you think could be related to this!)
- Added volume slider on right side of main interface
  - This replaces the volume scale slider under audio effects
  - The slider has a volume visualiser that shows the current volume in the left and right audio channels
  - It also shows the average volume
  - There is also another slider that points to the volume slider that controls the hard clipping point of the audio
    - The hard clipping point is the point at which the audio is clipped to the maximum volume
    - Any samples above this point are set to this point
    - By default, this is set to 1 meaning that any values less than -1 or greater than 1 are set to -1 or 1 respectively


![image](https://user-images.githubusercontent.com/38670946/192867962-a1e9a558-4d79-4587-9fe1-eafe25f0bdd7.png)
