### PR TITLE
Small fixes/improvements to text files and animations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>sh.ball</groupId>
     <artifactId>osci-render</artifactId>
-    <version>1.30.1</version>
+    <version>1.30.2</version>
 
     <name>osci-render</name>
 

--- a/src/main/java/sh/ball/audio/effect/EffectAnimator.java
+++ b/src/main/java/sh/ball/audio/effect/EffectAnimator.java
@@ -100,6 +100,11 @@ public class EffectAnimator extends PhaseEffect implements SettableEffect {
         }
       }
     }
+    if (actualValue > maxValue) {
+      actualValue = maxValue;
+    } else if (actualValue < minValue) {
+      actualValue = minValue;
+    }
     effect.setValue(actualValue);
     return effect.apply(count, vector);
   }

--- a/src/main/java/sh/ball/gui/components/EffectComponentGroupController.java
+++ b/src/main/java/sh/ball/gui/components/EffectComponentGroupController.java
@@ -250,7 +250,14 @@ public class EffectComponentGroupController implements Initializable, SubControl
     slider.minProperty().addListener((e, old, min) -> this.animator.setMin(min.doubleValue()));
     slider.maxProperty().addListener((e, old, max) -> this.animator.setMax(max.doubleValue()));
     slider.valueProperty().addListener((e, old, value) -> this.animator.setValue(value.doubleValue()));
-    comboBox.valueProperty().addListener((options, old, animationType) -> this.animator.setAnimation(animationType));
+    comboBox.valueProperty().addListener((options, old, animationType) -> {
+      this.animator.setAnimation(animationType);
+      if (animationType != AnimationType.STATIC) {
+        slider.setStyle("-thumb-color: #00ff00;");
+      } else {
+        slider.setStyle("");
+      }
+    });
   }
 
   public EffectAnimator getAnimator() {

--- a/src/main/java/sh/ball/parser/txt/TextParser.java
+++ b/src/main/java/sh/ball/parser/txt/TextParser.java
@@ -7,6 +7,8 @@ import java.io.*;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import javax.xml.parsers.ParserConfigurationException;
 
 import org.xml.sax.SAXException;
@@ -17,11 +19,11 @@ import sh.ball.shapes.Shape;
 
 public class TextParser extends FileParser<FrameSource<List<Shape>>> {
 
-  private static final char WIDE_CHAR = 'W';
-  private static final double HEIGHT_SCALAR = 1.6;
   private final InputStream input;
   private final String familyName;
   private final int style;
+  Pattern textSizePattern = Pattern.compile("^\\$text_size=(\\d+)");
+  Pattern escapePattern = Pattern.compile("\\\\(.)");
 
   public TextParser(InputStream input, String familyName, int style) {
     this.input = input;
@@ -34,20 +36,36 @@ public class TextParser extends FileParser<FrameSource<List<Shape>>> {
     return "txt";
   }
 
+  public double getLineHeight(Font font, FontRenderContext frc) {
+    return font.getMaxCharBounds(frc).getHeight();
+  }
+
   @Override
   public FrameSource<List<Shape>> parse() throws IllegalArgumentException, IOException, ParserConfigurationException, SAXException {
     String text = new String(input.readAllBytes(), StandardCharsets.UTF_8);
     Font font = new Font(familyName, style, 100);
     FontRenderContext frc = new FontRenderContext(null, false, false);
-    GlyphVector tallChar = font.createGlyphVector(frc, String.valueOf(WIDE_CHAR));
-    double lineHeight = tallChar.getPixelBounds(frc, 0, 0).getHeight();
 
     List<Shape> shapes = new ArrayList<>();
     float yOffset = 0;
     for (String line : text.split("\n")) {
+      Matcher matcher = textSizePattern.matcher(line);
+
+      if (matcher.find()) {
+        float size = Float.parseFloat(matcher.group(1));
+        line = matcher.replaceFirst("");
+        font = font.deriveFont(size);
+      } else {
+        font = font.deriveFont((float) 100);
+      }
+
+      matcher = escapePattern.matcher(line);
+
+      line = matcher.replaceAll("$1");
+
       GlyphVector glyphVector = font.createGlyphVector(frc, line);
+      yOffset += getLineHeight(font, frc);
       shapes.addAll(Shape.convert(glyphVector.getOutline(0, yOffset)));
-      yOffset += lineHeight;
     }
 
     return new ShapeFrameSource((Shape.normalize(shapes)));

--- a/src/main/resources/CHANGELOG.md
+++ b/src/main/resources/CHANGELOG.md
@@ -1,3 +1,14 @@
+- 1.30.2
+  - Allow text size to be specified when creating .txt files
+    - Write "$text_size=" followed by a number to change the text size for that line
+    - e.g. "$text_size=50" will make the text size 50 for that line
+    - The default text size is 100
+    - If for some reason you still want to write "$text_size=", you can escape it with a backslash. e.g. "\$text_size=50"
+    - This slightly changes the syntax for writing a backslash, as you now need to write "\\" instead of "\"
+  - Fix a bug where the animations would get stuck if the bounds of the slider/effect were changed while the animation was playing
+  - The knobs/thumbs of sliders now change to green when the slider/effect is being animated
+
+
 - 1.30.1
   - Changed Lua demo file to the mini osci-render demo that emulates a basic version of osci-render within osci-render
   - Done this as the old demo's audio was quite jarring and the new one shows off more of Lua

--- a/src/main/resources/CHANGELOG.md
+++ b/src/main/resources/CHANGELOG.md
@@ -3,8 +3,8 @@
     - Write "$text_size=" followed by a number to change the text size for that line
     - e.g. "$text_size=50" will make the text size 50 for that line
     - The default text size is 100
-    - If for some reason you still want to write "$text_size=", you can escape it with a backslash. e.g. "\$text_size=50"
-    - This slightly changes the syntax for writing a backslash, as you now need to write "\\" instead of "\"
+    - If for some reason you still want to write "$text_size=", you can escape it with a backslash. e.g. "\\$text_size=50"
+    - This slightly changes the syntax for writing a backslash, as you now need to write "\\\\" instead of "\\"
   - Fix a bug where the animations would get stuck if the bounds of the slider/effect were changed while the animation was playing
   - The knobs/thumbs of sliders now change to green when the slider/effect is being animated
 

--- a/src/main/resources/css/main.css
+++ b/src/main/resources/css/main.css
@@ -102,9 +102,13 @@
     -fx-text-fill: white;
 }
 
+.slider {
+    -thumb-color: white;
+}
+
 .slider .thumb {
     -fx-background-color: very_dark;
-    -fx-border-color: white;
+    -fx-border-color: -thumb-color;
     -fx-border-radius: 1.0em; /* makes sure this remains circular */
     -fx-effect: inherit;
 }

--- a/src/main/resources/fxml/projectSelect.fxml
+++ b/src/main/resources/fxml/projectSelect.fxml
@@ -43,7 +43,7 @@
                      <CheckBox fx:id="startMutedCheckBox" mnemonicParsing="false" text="Start muted" />
                      <HBox alignment="CENTER" spacing="20.0">
                         <children>
-                           <Label minWidth="42.0" prefHeight="18.0" prefWidth="42.0" text="v1.30.1" />
+                           <Label minWidth="42.0" prefHeight="18.0" prefWidth="42.0" text="v1.30.2" />
                            <Label prefHeight="54.0" prefWidth="379.0" text="Email me at james@ball.sh or create an issue on GitHub for feature suggestions, issues, or opportunites I might be interested in!" textAlignment="CENTER" wrapText="true" />
                            <Button fx:id="logButton" minWidth="102.0" mnemonicParsing="false" prefWidth="102.0" text="Open log folder" />
                         </children>


### PR DESCRIPTION
- Allow text size to be specified when creating .txt files
    - Write "$text_size=" followed by a number to change the text size for that line
    - e.g. "$text_size=50" will make the text size 50 for that line
    - The default text size is 100
    - If for some reason you still want to write "$text_size=", you can escape it with a backslash. e.g. "\\$text_size=50"
    - This slightly changes the syntax for writing a backslash, as you now need to write "\\\\" instead of "\\"
- Fix a bug where the animations would get stuck if the bounds of the slider/effect were changed while the animation was playing
- The knobs/thumbs of sliders now change to green when the slider/effect is being animated