### PR TITLE
Delay and Bulge effects

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>sh.ball</groupId>
     <artifactId>osci-render</artifactId>
-    <version>1.31.0</version>
+    <version>1.32.0</version>
 
     <name>osci-render</name>
 

--- a/src/main/java/sh/ball/audio/AudioUtil.java
+++ b/src/main/java/sh/ball/audio/AudioUtil.java
@@ -1,0 +1,11 @@
+package sh.ball.audio;
+
+import sh.ball.audio.engine.AudioDevice;
+
+public class AudioUtil {
+  private static final int MIN_FRAME_LATENCY = 512;
+
+  public static int calculateBufferSize(int sampleRate, int frameSize, int latencyMs) {
+    return Math.max((int) (sampleRate * latencyMs * 0.0005), MIN_FRAME_LATENCY) * frameSize;
+  }
+}

--- a/src/main/java/sh/ball/audio/ShapeAudioPlayer.java
+++ b/src/main/java/sh/ball/audio/ShapeAudioPlayer.java
@@ -1,5 +1,6 @@
 package sh.ball.audio;
 
+import be.tarsos.dsp.effects.DelayEffect;
 import sh.ball.audio.effect.*;
 
 import java.io.*;

--- a/src/main/java/sh/ball/audio/effect/AudioProcessorEffect.java
+++ b/src/main/java/sh/ball/audio/effect/AudioProcessorEffect.java
@@ -1,0 +1,38 @@
+package sh.ball.audio.effect;
+
+import be.tarsos.dsp.AudioEvent;
+import be.tarsos.dsp.AudioProcessor;
+import be.tarsos.dsp.io.TarsosDSPAudioFormat;
+import sh.ball.audio.engine.AudioDevice;
+import sh.ball.shapes.Vector2;
+
+public class AudioProcessorEffect implements Effect {
+
+  private static final boolean BIG_ENDIAN = false;
+  private final AudioProcessor processor;
+  private AudioEvent event;
+
+  private final float[] buffer = new float[2];
+
+  public AudioProcessorEffect(AudioProcessor processor) {
+    this.processor = processor;
+  }
+
+  public void setDevice(AudioDevice device) {
+    event = new AudioEvent(new TarsosDSPAudioFormat(device.sampleRate(), device.sample().size, device.channels(), device.sample().signed, BIG_ENDIAN));
+    event.setFloatBuffer(buffer);
+  }
+
+  @Override
+  public Vector2 apply(int count, Vector2 vector) {
+    if (event == null) {
+      return vector;
+    }
+    buffer[0] = (float) vector.x;
+    buffer[1] = (float) vector.y;
+
+    processor.process(event);
+
+    return new Vector2(buffer[0], buffer[1]);
+  }
+}

--- a/src/main/java/sh/ball/audio/effect/BulgeEffect.java
+++ b/src/main/java/sh/ball/audio/effect/BulgeEffect.java
@@ -1,0 +1,24 @@
+package sh.ball.audio.effect;
+
+import sh.ball.shapes.Vector2;
+
+public class BulgeEffect implements SettableEffect {
+
+  private double bulge = 0.1;
+
+  @Override
+  public Vector2 apply(int count, Vector2 vector) {
+    double translatedBulge = -bulge + 1;
+
+    double r = vector.magnitude();
+    double theta = Math.atan2(vector.y, vector.x);
+    double rn = Math.pow(r, translatedBulge);
+
+    return new Vector2(rn * Math.cos(theta), rn * Math.sin(theta));
+  }
+
+  @Override
+  public void setValue(double value) {
+    this.bulge = value;
+  }
+}

--- a/src/main/java/sh/ball/audio/effect/DelayEffect.java
+++ b/src/main/java/sh/ball/audio/effect/DelayEffect.java
@@ -1,0 +1,116 @@
+package sh.ball.audio.effect;
+
+/*
+ *      _______                       _____   _____ _____
+ *     |__   __|                     |  __ \ / ____|  __ \
+ *        | | __ _ _ __ ___  ___  ___| |  | | (___ | |__) |
+ *        | |/ _` | '__/ __|/ _ \/ __| |  | |\___ \|  ___/
+ *        | | (_| | |  \__ \ (_) \__ \ |__| |____) | |
+ *        |_|\__,_|_|  |___/\___/|___/_____/|_____/|_|
+ *
+ * -------------------------------------------------------------
+ *
+ * TarsosDSP is developed by Joren Six at IPEM, University Ghent
+ *
+ * -------------------------------------------------------------
+ *
+ *  Info: http://0110.be/tag/TarsosDSP
+ *  Github: https://github.com/JorenSix/TarsosDSP
+ *  Releases: http://0110.be/releases/TarsosDSP/
+ *
+ *  TarsosDSP includes modified source code by various authors,
+ *  for credits and info, see README.
+ *
+ *
+ *  THIS IS A MODIFIED VERSION BY JAMES H BALL FOR OSCI-RENDER
+ *
+ *
+ */
+
+
+import java.util.Arrays;
+import sh.ball.shapes.Vector2;
+
+/**
+ * <p>
+ * Adds an echo effect to the signal.
+ * </p>
+ *
+ * @author Joren Six
+ */
+public class DelayEffect implements SettableEffect {
+
+  private final static int MAX_DELAY = 192000 * 10;
+
+  private final Vector2[] echoBuffer;
+  private double sampleRate;
+  private int head;
+  private double decay;
+  private double echoLength;
+  private int position;
+
+  private int echoBufferLength;
+  private int samplesSinceLastEcho = 0;
+
+  /**
+   * @param echoLength in seconds
+   * @param sampleRate the sample rate in Hz.
+   * @param decay The decay of the echo, a value between 0 and 1. 1 meaning no decay, 0 means immediate decay (not echo effect).
+   */
+  public DelayEffect(double echoLength, double decay, double sampleRate) {
+    this.sampleRate = sampleRate;
+    this.echoBuffer = new Vector2[MAX_DELAY];
+    Arrays.fill(echoBuffer, new Vector2());
+    this.decay = decay;
+    setEchoLength(echoLength);
+  }
+
+  /**
+   * @param newEchoLength A new echo buffer length in seconds.
+   */
+  public void setEchoLength(double newEchoLength) {
+    this.echoLength = newEchoLength;
+    this.echoBufferLength = (int) (echoLength * sampleRate);
+  }
+
+  public void setSampleRate(double sampleRate){
+    this.sampleRate = sampleRate;
+    this.echoBufferLength = (int) (echoLength * sampleRate);
+  }
+
+  @Override
+  public Vector2 apply(int count, Vector2 vector) {
+    if (head >= echoBuffer.length){
+      head = 0;
+    }
+    if (position >= echoBuffer.length){
+      position = 0;
+    }
+    if (samplesSinceLastEcho >= echoBufferLength) {
+      samplesSinceLastEcho = 0;
+      position = head - echoBufferLength;
+      if (position < 0) {
+        position += echoBuffer.length;
+      }
+    }
+
+    Vector2 echo = echoBuffer[position];
+    vector = new Vector2(
+        vector.x + echo.x * decay,
+        vector.y + echo.y * decay
+    );
+
+    echoBuffer[head] = vector;
+
+    head++;
+    position++;
+    samplesSinceLastEcho++;
+
+    return vector;
+  }
+
+  @Override
+  public void setValue(double value) {
+    decay = value;
+  }
+}

--- a/src/main/java/sh/ball/audio/effect/EffectType.java
+++ b/src/main/java/sh/ball/audio/effect/EffectType.java
@@ -29,7 +29,9 @@ public enum EffectType {
   LUA_B(-1),
   LUA_C(-1),
   LUA_D(-1),
-  LUA_E(-1);
+  LUA_E(-1),
+  DELAY_DECAY(101),
+  DELAY_ECHO_LENGTH(-1),;
 
   public final int precedence;
 

--- a/src/main/java/sh/ball/audio/effect/EffectType.java
+++ b/src/main/java/sh/ball/audio/effect/EffectType.java
@@ -31,7 +31,8 @@ public enum EffectType {
   LUA_D(-1),
   LUA_E(-1),
   DELAY_DECAY(101),
-  DELAY_ECHO_LENGTH(-1),;
+  DELAY_ECHO_LENGTH(-1),
+  BULGE(53);
 
   public final int precedence;
 

--- a/src/main/java/sh/ball/gui/controller/EffectsController.java
+++ b/src/main/java/sh/ball/gui/controller/EffectsController.java
@@ -23,7 +23,6 @@ import sh.ball.parser.lua.LuaExecutor;
 import sh.ball.shapes.Shape;
 import sh.ball.shapes.Vector2;
 
-import java.awt.*;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
@@ -93,6 +92,8 @@ public class EffectsController implements Initializable, SubController {
   private EffectComponentGroup delayEchoLength;
   @FXML
   private EffectComponentGroup delayDecay;
+  @FXML
+  private EffectComponentGroup bulge;
   @FXML
   private TextField translationXTextField;
   @FXML
@@ -204,6 +205,7 @@ public class EffectsController implements Initializable, SubController {
     backingMidi.setAnimator(new EffectAnimator(DEFAULT_SAMPLE_RATE, new ConsumerEffect(audioPlayer::setBackingMidiVolume)));
     delayDecay.setAnimator(new EffectAnimator(DEFAULT_SAMPLE_RATE, delayEffect));
     delayEchoLength.setAnimator(new EffectAnimator(DEFAULT_SAMPLE_RATE, new ConsumerEffect((value) -> delayEffect.setEchoLength(value))));
+    bulge.setAnimator(new EffectAnimator(DEFAULT_SAMPLE_RATE, new BulgeEffect()));
 
     effects().forEach(effect -> {
       effect.setEffectUpdater(this::updateEffect);
@@ -298,7 +300,8 @@ public class EffectsController implements Initializable, SubController {
       rotateSpeed,
       backingMidi,
       delayDecay,
-      delayEchoLength
+      delayEchoLength,
+      bulge
     );
   }
 

--- a/src/main/java/sh/ball/gui/controller/EffectsController.java
+++ b/src/main/java/sh/ball/gui/controller/EffectsController.java
@@ -44,6 +44,7 @@ public class EffectsController implements Initializable, SubController {
   private final PerspectiveEffect perspectiveEffect;
   private final TranslateEffect translateEffect;
   private final RotateEffect rotateEffect;
+  private DelayEffect delayEffect;
 
   private double scrollDelta = 0.05;
   private String script = DEFAULT_SCRIPT;
@@ -89,6 +90,10 @@ public class EffectsController implements Initializable, SubController {
   @FXML
   private EffectComponentGroup backingMidi;
   @FXML
+  private EffectComponentGroup delayEchoLength;
+  @FXML
+  private EffectComponentGroup delayDecay;
+  @FXML
   private TextField translationXTextField;
   @FXML
   private TextField translationYTextField;
@@ -116,6 +121,7 @@ public class EffectsController implements Initializable, SubController {
     this.perspectiveEffect = new PerspectiveEffect(executor);
     this.translateEffect = new TranslateEffect(DEFAULT_SAMPLE_RATE, 1, new Vector2());
     this.rotateEffect = new RotateEffect(DEFAULT_SAMPLE_RATE);
+    this.delayEffect = new DelayEffect(0.5, 0.5, DEFAULT_SAMPLE_RATE);
   }
 
   private <K, V> Map<K, V> mergeEffectMaps(Function<EffectComponentGroup, Map<K, V>> map) {
@@ -143,6 +149,8 @@ public class EffectsController implements Initializable, SubController {
       Platform.runLater(() ->
         List.of(rotateSpeed3D, rotateX, rotateY, rotateZ, zPos).forEach(ecg -> ecg.setInactive(!checked))
       );
+    } else if (type == EffectType.DELAY_DECAY) {
+      Platform.runLater(() -> delayEchoLength.setInactive(!checked));
     }
   }
 
@@ -150,6 +158,7 @@ public class EffectsController implements Initializable, SubController {
     wobbleEffect.setSampleRate(device.sampleRate());
     translateEffect.setSampleRate(device.sampleRate());
     rotateEffect.setSampleRate(device.sampleRate());
+    delayEffect.setSampleRate(device.sampleRate());
     Map<ComboBox<AnimationType>, EffectAnimator> comboAnimatorMap = getComboBoxAnimatorMap();
     for (EffectAnimator animator : comboAnimatorMap.values()) {
       animator.setSampleRate(device.sampleRate());
@@ -193,6 +202,8 @@ public class EffectsController implements Initializable, SubController {
     translationSpeed.setAnimator(new EffectAnimator(DEFAULT_SAMPLE_RATE, new ConsumerEffect(translateEffect::setSpeed)));
     rotateSpeed.setAnimator(new EffectAnimator(DEFAULT_SAMPLE_RATE, rotateEffect));
     backingMidi.setAnimator(new EffectAnimator(DEFAULT_SAMPLE_RATE, new ConsumerEffect(audioPlayer::setBackingMidiVolume)));
+    delayDecay.setAnimator(new EffectAnimator(DEFAULT_SAMPLE_RATE, delayEffect));
+    delayEchoLength.setAnimator(new EffectAnimator(DEFAULT_SAMPLE_RATE, new ConsumerEffect((value) -> delayEffect.setEchoLength(value))));
 
     effects().forEach(effect -> {
       effect.setEffectUpdater(this::updateEffect);
@@ -239,6 +250,7 @@ public class EffectsController implements Initializable, SubController {
     depthFunctionButton.setOnAction(e -> Gui.launchCodeEditor(script, "3D Perspective Effect Depth Function", "text/x-lua", this::updateDepthFunction));
 
     List.of(rotateSpeed3D, rotateX, rotateY, rotateZ, zPos).forEach(ecg -> ecg.setInactive(true));
+    delayEchoLength.setInactive(true);
 
     fixedAngleX.setOnMouseClicked(e -> {
       setFixedAngleX = !setFixedAngleX;
@@ -284,7 +296,9 @@ public class EffectsController implements Initializable, SubController {
       translationScale,
       translationSpeed,
       rotateSpeed,
-      backingMidi
+      backingMidi,
+      delayDecay,
+      delayEchoLength
     );
   }
 

--- a/src/main/java/sh/ball/shapes/Vector2.java
+++ b/src/main/java/sh/ball/shapes/Vector2.java
@@ -113,4 +113,8 @@ public final class Vector2 extends Shape {
       ", y=" + y +
       '}';
   }
+
+  public double magnitude() {
+    return Math.sqrt(x * x + y * y);
+  }
 }

--- a/src/main/resources/CHANGELOG.md
+++ b/src/main/resources/CHANGELOG.md
@@ -1,3 +1,11 @@
+- 1.32.0
+  - Added two new audio effects: Delay/Echo and Bulge
+  - Delay effect can be used to create an echo of the audio signal
+    - Controllable with both the echo length and the decay of the echo
+  - Bulge effect makes the image bulge outwards
+    - If you change the minimum slider value to something negative using the Slider settings, you can make the image bulge inwards
+
+
 - 1.31.0
   - Support audio input from microphone/sound card as an audio source
     - Just click the microphone button next to where you choose a file to open

--- a/src/main/resources/fxml/effects.fxml
+++ b/src/main/resources/fxml/effects.fxml
@@ -13,7 +13,7 @@
 <?import javafx.scene.shape.SVGPath?>
 <?import sh.ball.gui.components.EffectComponentGroup?>
 
-<ScrollPane fitToHeight="true" fitToWidth="true" hbarPolicy="NEVER" prefHeight="1168.0" prefWidth="605.0" xmlns="http://javafx.com/javafx/19" xmlns:fx="http://javafx.com/fxml/1" fx:controller="sh.ball.gui.controller.EffectsController">
+<ScrollPane fitToHeight="true" fitToWidth="true" hbarPolicy="NEVER" prefHeight="1214.0" prefWidth="605.0" xmlns="http://javafx.com/javafx/19" xmlns:fx="http://javafx.com/fxml/1" fx:controller="sh.ball.gui.controller.EffectsController">
    <content>
       <FlowPane prefHeight="1094.0" prefWidth="605.0" prefWrapLength="100.0" rowValignment="BASELINE">
          <children>
@@ -135,11 +135,12 @@
                   </AnchorPane>
                    <EffectComponentGroup fx:id="traceMax" increment="0.005" label="traceMax" majorTickUnit="0.1" max="1.0" min="0.0" name="Trace max" type="TRACE_MAX" value="0.5" />
                    <EffectComponentGroup fx:id="traceMin" increment="0.005" label="traceMin" majorTickUnit="0.1" max="1.0" min="0.0" name="Trace min" type="TRACE_MIN" value="0.5" />
+                  <EffectComponentGroup fx:id="bulge" increment="0.005" label="bulge" majorTickUnit="0.1" max="1.0" min="0.0" name="Bulge" type="BULGE" value="0.1" />
                </children>
             </VBox>
             <VBox>
                <children>
-                  <Label alignment="CENTER" prefWidth="601.0" text="Output" textAlignment="JUSTIFY">
+                  <Label alignment="CENTER" prefWidth="601.0" text="Delay" textAlignment="JUSTIFY">
                      <padding>
                         <Insets bottom="5.0" />
                      </padding>

--- a/src/main/resources/fxml/effects.fxml
+++ b/src/main/resources/fxml/effects.fxml
@@ -13,9 +13,9 @@
 <?import javafx.scene.shape.SVGPath?>
 <?import sh.ball.gui.components.EffectComponentGroup?>
 
-<ScrollPane fitToHeight="true" fitToWidth="true" hbarPolicy="NEVER" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1" fx:controller="sh.ball.gui.controller.EffectsController">
+<ScrollPane fitToHeight="true" fitToWidth="true" hbarPolicy="NEVER" prefHeight="1168.0" prefWidth="605.0" xmlns="http://javafx.com/javafx/19" xmlns:fx="http://javafx.com/fxml/1" fx:controller="sh.ball.gui.controller.EffectsController">
    <content>
-      <FlowPane prefHeight="1094.0" prefWidth="603.0" prefWrapLength="100.0" rowValignment="BASELINE">
+      <FlowPane prefHeight="1094.0" prefWidth="605.0" prefWrapLength="100.0" rowValignment="BASELINE">
          <children>
             <VBox>
                <children>
@@ -135,6 +135,25 @@
                   </AnchorPane>
                    <EffectComponentGroup fx:id="traceMax" increment="0.005" label="traceMax" majorTickUnit="0.1" max="1.0" min="0.0" name="Trace max" type="TRACE_MAX" value="0.5" />
                    <EffectComponentGroup fx:id="traceMin" increment="0.005" label="traceMin" majorTickUnit="0.1" max="1.0" min="0.0" name="Trace min" type="TRACE_MIN" value="0.5" />
+               </children>
+            </VBox>
+            <VBox>
+               <children>
+                  <Label alignment="CENTER" prefWidth="601.0" text="Output" textAlignment="JUSTIFY">
+                     <padding>
+                        <Insets bottom="5.0" />
+                     </padding>
+                  </Label>
+                  <Separator prefWidth="200.0">
+                     <opaqueInsets>
+                        <Insets />
+                     </opaqueInsets>
+                     <padding>
+                        <Insets bottom="5.0" />
+                     </padding>
+                  </Separator>
+                  <EffectComponentGroup fx:id="delayDecay" increment="0.005" label="delayDecay" max="1.0" min="0.0" name="Echo Decay" type="DELAY_DECAY" value="0.5" />
+                  <EffectComponentGroup fx:id="delayEchoLength" alwaysEnabled="true" increment="0.01" label="delayEchoLength" majorTickUnit="0.25" max="2.0" min="0.0" name="Echo Length" type="DELAY_ECHO_LENGTH" value="0.5" />
                </children>
             </VBox>
          </children>

--- a/src/main/resources/fxml/projectSelect.fxml
+++ b/src/main/resources/fxml/projectSelect.fxml
@@ -43,7 +43,7 @@
                      <CheckBox fx:id="startMutedCheckBox" mnemonicParsing="false" text="Start muted" />
                      <HBox alignment="CENTER" spacing="20.0">
                         <children>
-                           <Label fx:id="versionLabel" minWidth="42.0" prefHeight="18.0" prefWidth="42.0" text="v1.31.0" />
+                           <Label fx:id="versionLabel" minWidth="42.0" prefHeight="18.0" prefWidth="42.0" text="v1.32.0" />
                            <Label prefHeight="54.0" prefWidth="379.0" text="Email me at james@ball.sh or create an issue on GitHub for feature suggestions, issues, or opportunites I might be interested in!" textAlignment="CENTER" wrapText="true" />
                            <Button fx:id="logButton" minWidth="102.0" mnemonicParsing="false" prefWidth="102.0" text="Open log folder" />
                         </children>


### PR DESCRIPTION
  - Added two new audio effects: Delay/Echo and Bulge
  - Delay effect can be used to create an echo of the audio signal
    - Controllable with both the echo length and the decay of the echo
  - Bulge effect makes the image bulge outwards
    - If you change the minimum slider value to something negative using the Slider settings, you can make the image bulge inwards