### PR TITLE
Enable OpenGL on Windows and Linux

### DIFF
--- a/Source/PluginEditor.cpp
+++ b/Source/PluginEditor.cpp
@@ -5,6 +5,11 @@
 OscirenderAudioProcessorEditor::OscirenderAudioProcessorEditor(OscirenderAudioProcessor& p)
 	: AudioProcessorEditor(&p), audioProcessor(p), collapseButton("Collapse", juce::Colours::white, juce::Colours::white, juce::Colours::white)
 {
+#if !JUCE_MAC
+    // use OpenGL on Windows and Linux for much better performance. The default on Mac is CoreGraphics which is much faster.
+    openGlContext.attachTo(*getTopLevelComponent());
+#endif
+
     setLookAndFeel(&lookAndFeel);
     addAndMakeVisible(volume);
 

--- a/Source/PluginEditor.h
+++ b/Source/PluginEditor.h
@@ -65,6 +65,10 @@ private:
 
     bool usingNativeMenuBar = false;
 
+#if !JUCE_MAC
+    juce::OpenGLContext openGlContext;
+#endif
+
 	void codeDocumentTextInserted(const juce::String& newText, int insertIndex) override;
 	void codeDocumentTextDeleted(int startIndex, int endIndex) override;
     void updateCodeDocument();

--- a/osci-render.jucer
+++ b/osci-render.jucer
@@ -5,7 +5,7 @@
               pluginCharacteristicsValue="pluginProducesMidiOut,pluginWantsMidiIn"
               pluginManufacturer="jameshball" aaxIdentifier="sh.ball.oscirender"
               cppLanguageStandard="20" projectLineFeed="&#10;" headerPath="./include"
-              version="2.0.2" companyName="James H Ball" companyWebsite="https://osci-render.com"
+              version="2.0.3" companyName="James H Ball" companyWebsite="https://osci-render.com"
               companyEmail="james@ball.sh">
   <MAINGROUP id="j5Ge2T" name="osci-render">
     <GROUP id="{5ABCED88-0059-A7AF-9596-DBF91DDB0292}" name="Resources">


### PR DESCRIPTION
Leads to massively improved performance of the interface on Windows, closing #177 