### PR TITLE
Fullscreen visualiser

### DIFF
--- a/Source/MainComponent.cpp
+++ b/Source/MainComponent.cpp
@@ -90,7 +90,30 @@ MainComponent::MainComponent(OscirenderAudioProcessor& p, OscirenderAudioProcess
 		createFile.triggerClick();
 	};
 
-	addAndMakeVisible(visualiser);
+	if (!pluginEditor.visualiserFullScreen) {
+		addAndMakeVisible(pluginEditor.visualiser);
+	}
+	pluginEditor.visualiser.setFullScreenCallback([this](FullScreenMode mode) {
+		if (mode == FullScreenMode::TOGGLE) {
+            pluginEditor.visualiserFullScreen = !pluginEditor.visualiserFullScreen;
+		} else if (mode == FullScreenMode::FULL_SCREEN) {
+            pluginEditor.visualiserFullScreen = true;
+		} else if (mode == FullScreenMode::MAIN_COMPONENT) {
+            pluginEditor.visualiserFullScreen = false;
+        }
+
+		if (pluginEditor.visualiserFullScreen) {
+			removeChildComponent(&pluginEditor.visualiser);
+			pluginEditor.addAndMakeVisible(pluginEditor.visualiser);
+		} else {
+			pluginEditor.removeChildComponent(&pluginEditor.visualiser);
+			addAndMakeVisible(pluginEditor.visualiser);
+		}
+		pluginEditor.resized();
+		pluginEditor.repaint();
+		resized();
+		repaint();
+    });
 	addAndMakeVisible(openOscilloscope);
 
 	openOscilloscope.onClick = [this] {
@@ -151,15 +174,18 @@ void MainComponent::resized() {
 	frequencyLabel.setBounds(bounds.removeFromTop(20));
 
 	bounds.removeFromTop(padding);
-	// openOscilloscope.setBounds(bounds.removeFromBottom(buttonHeight).withSizeKeepingCentre(160, buttonHeight));
-	auto minDim = juce::jmin(bounds.getWidth(), bounds.getHeight());
-	visualiser.setBounds(bounds.withSizeKeepingCentre(minDim, minDim));
+	if (!pluginEditor.visualiserFullScreen) {
+		auto minDim = juce::jmin(bounds.getWidth(), bounds.getHeight());
+		pluginEditor.visualiser.setBounds(bounds.withSizeKeepingCentre(minDim, minDim));
+	}
 }
 
 void MainComponent::paint(juce::Graphics& g) {
 	juce::GroupComponent::paint(g);
 
-	// add drop shadow to the visualiser
-	auto dc = juce::DropShadow(juce::Colours::black, 30, juce::Point<int>(0, 0));
-	dc.drawForRectangle(g, visualiser.getBounds());
+	if (!pluginEditor.visualiserFullScreen) {
+		// add drop shadow to the visualiser
+		auto dc = juce::DropShadow(juce::Colours::black, 30, juce::Point<int>(0, 0));
+		dc.drawForRectangle(g, pluginEditor.visualiser.getBounds());
+	}
 }

--- a/Source/MainComponent.h
+++ b/Source/MainComponent.h
@@ -32,7 +32,6 @@ private:
 	juce::ComboBox fileType;
 	juce::TextButton createFile{"Create File"};
 
-	VisualiserComponent visualiser{2, audioProcessor};
 	juce::TextButton openOscilloscope{"Open Oscilloscope"};
 
 	juce::Label frequencyLabel;

--- a/Source/PluginEditor.cpp
+++ b/Source/PluginEditor.cpp
@@ -5,6 +5,11 @@
 OscirenderAudioProcessorEditor::OscirenderAudioProcessorEditor(OscirenderAudioProcessor& p)
 	: AudioProcessorEditor(&p), audioProcessor(p), collapseButton("Collapse", juce::Colours::white, juce::Colours::white, juce::Colours::white)
 {
+#if !JUCE_MAC
+    // use OpenGL on Windows and Linux for much better performance. The default on Mac is CoreGraphics which is much faster.
+    openGlContext.attachTo(*getTopLevelComponent());
+#endif
+
     setLookAndFeel(&lookAndFeel);
     addAndMakeVisible(volume);
 

--- a/Source/PluginEditor.cpp
+++ b/Source/PluginEditor.cpp
@@ -80,6 +80,10 @@ OscirenderAudioProcessorEditor::OscirenderAudioProcessorEditor(OscirenderAudioPr
 
     addAndMakeVisible(settings);
     addAndMakeVisible(resizerBar);
+
+    if (visualiserFullScreen) {
+        addAndMakeVisible(visualiser);
+    }
 }
 
 OscirenderAudioProcessorEditor::~OscirenderAudioProcessorEditor() {
@@ -130,6 +134,12 @@ void OscirenderAudioProcessorEditor::paint(juce::Graphics& g) {
 
 void OscirenderAudioProcessorEditor::resized() {
     auto area = getLocalBounds();
+
+    if (visualiserFullScreen) {
+        visualiser.setBounds(area);
+        return;
+    }
+
     if (!usingNativeMenuBar) {
         menuBar.setBounds(area.removeFromTop(25));
     }
@@ -327,7 +337,7 @@ void OscirenderAudioProcessorEditor::updateCodeDocument() {
 }
 
 bool OscirenderAudioProcessorEditor::keyPressed(const juce::KeyPress& key) {
-    bool consumeKey1 = true;
+    bool consumeKey = false;
     {
         juce::SpinLock::ScopedLockType parserLock(audioProcessor.parsersLock);
         juce::SpinLock::ScopedLockType effectsLock(audioProcessor.effectsLock);
@@ -344,6 +354,7 @@ bool OscirenderAudioProcessorEditor::keyPressed(const juce::KeyPress& key) {
                 }
                 changedFile = true;
             }
+            consumeKey = true;
         } else if (key.getTextCharacter() == 'k') {
             if (numFiles > 1) {
                 currentFile--;
@@ -352,8 +363,7 @@ bool OscirenderAudioProcessorEditor::keyPressed(const juce::KeyPress& key) {
                 }
                 changedFile = true;
             }
-        } else {
-            consumeKey1 = false;
+            consumeKey = true;
         }
 
         if (changedFile) {
@@ -362,7 +372,6 @@ bool OscirenderAudioProcessorEditor::keyPressed(const juce::KeyPress& key) {
         }
     }
     
-    bool consumeKey2 = true;
     if (key.isKeyCode(juce::KeyPress::escapeKey)) {
         settings.disableMouseRotation();
     } else if (key.getModifiers().isCommandDown() && key.getModifiers().isShiftDown() && key.getKeyCode() == 'S') {
@@ -371,11 +380,9 @@ bool OscirenderAudioProcessorEditor::keyPressed(const juce::KeyPress& key) {
         saveProject();
     } else if (key.getModifiers().isCommandDown() && key.getKeyCode() == 'O') {
         openProject();
-    } else {
-        consumeKey2 = false;
-	}
+    }
 
-    return consumeKey1 || consumeKey2;
+    return consumeKey;
 }
 
 void OscirenderAudioProcessorEditor::newProject() {

--- a/Source/PluginEditor.h
+++ b/Source/PluginEditor.h
@@ -65,6 +65,10 @@ private:
 
     bool usingNativeMenuBar = false;
 
+#if !JUCE_MAC
+    juce::OpenGLContext openGlContext;
+#endif
+
 	void codeDocumentTextInserted(const juce::String& newText, int insertIndex) override;
 	void codeDocumentTextDeleted(int startIndex, int endIndex) override;
     void updateCodeDocument();

--- a/Source/PluginEditor.h
+++ b/Source/PluginEditor.h
@@ -35,14 +35,19 @@ public:
     void openAudioSettings();
     void resetToDefault();
 
-    std::atomic<bool> editingPerspective = false;
-
-    OscirenderLookAndFeel lookAndFeel;
 private:
     OscirenderAudioProcessor& audioProcessor;
-    
+public:
+
+    OscirenderLookAndFeel lookAndFeel;
+
+    std::atomic<bool> editingPerspective = false;
+
+    VisualiserComponent visualiser{2, audioProcessor};
+    std::atomic<bool> visualiserFullScreen = false;
     SettingsComponent settings{audioProcessor, *this};
     VolumeComponent volume{audioProcessor};
+
     std::vector<std::shared_ptr<juce::CodeDocument>> codeDocuments;
     std::vector<std::shared_ptr<ErrorCodeEditorComponent>> codeEditors;
     juce::CodeEditorComponent::ColourScheme colourScheme;

--- a/Source/components/VisualiserComponent.cpp
+++ b/Source/components/VisualiserComponent.cpp
@@ -8,11 +8,25 @@ VisualiserComponent::VisualiserComponent(int numChannels, OscirenderAudioProcess
     
     roughness.textBox.setValue(4);
     intensity.textBox.setValue(1.0);
+
+    setMouseCursor(juce::MouseCursor::PointingHandCursor);
+    setWantsKeyboardFocus(true);
 }
 
 VisualiserComponent::~VisualiserComponent() {
     audioProcessor.consumerStop(consumer);
     stopThread(1000);
+}
+
+void VisualiserComponent::setFullScreenCallback(std::function<void(FullScreenMode)> callback) {
+    fullScreenCallback = callback;
+}
+
+void VisualiserComponent::mouseDoubleClick(const juce::MouseEvent& event) {
+    if (fullScreenCallback) {
+        fullScreenCallback(FullScreenMode::TOGGLE);
+    }
+    grabKeyboardFocus();
 }
 
 void VisualiserComponent::setBuffer(std::vector<float>& newBuffer) {
@@ -92,6 +106,17 @@ void VisualiserComponent::mouseDown(const juce::MouseEvent& event) {
 
         menu.showMenuAsync(juce::PopupMenu::Options(), [this](int result) {});
     }
+}
+
+bool VisualiserComponent::keyPressed(const juce::KeyPress& key) {
+    if (key.isKeyCode(juce::KeyPress::escapeKey)) {
+        if (fullScreenCallback) {
+            fullScreenCallback(FullScreenMode::MAIN_COMPONENT);
+        }
+        return true;
+    }
+
+    return false;
 }
 
 void VisualiserComponent::paintChannel(juce::Graphics& g, juce::Rectangle<float> area, int channel) {

--- a/Source/components/VisualiserComponent.h
+++ b/Source/components/VisualiserComponent.h
@@ -7,11 +7,19 @@
 #include "../PluginProcessor.h"
 #include "LabelledTextBox.h"
 
+enum class FullScreenMode {
+    TOGGLE,
+    FULL_SCREEN,
+    MAIN_COMPONENT,
+};
+
 class VisualiserComponent : public juce::Component, public juce::Timer, public juce::Thread, public juce::MouseListener {
 public:
     VisualiserComponent(int numChannels, OscirenderAudioProcessor& p);
     ~VisualiserComponent() override;
 
+    void setFullScreenCallback(std::function<void(FullScreenMode)> callback);
+    void mouseDoubleClick(const juce::MouseEvent& event) override;
     void setBuffer(std::vector<float>& buffer);
     void setColours(juce::Colour backgroundColour, juce::Colour waveformColour);
     void paintChannel(juce::Graphics&, juce::Rectangle<float> bounds, int channel);
@@ -20,6 +28,8 @@ public:
 	void timerCallback() override;
 	void run() override;
     void mouseDown(const juce::MouseEvent& event) override;
+    bool keyPressed(const juce::KeyPress& key) override;
+
 
 private:
     const double BUFFER_LENGTH_SECS = 0.02;
@@ -41,6 +51,8 @@ private:
     std::atomic<bool> active = true;
     
     std::shared_ptr<BufferConsumer> consumer;
+
+    std::function<void(FullScreenMode)> fullScreenCallback;
     
     void resetBuffer();
 

--- a/osci-render.jucer
+++ b/osci-render.jucer
@@ -5,7 +5,7 @@
               pluginCharacteristicsValue="pluginProducesMidiOut,pluginWantsMidiIn"
               pluginManufacturer="jameshball" aaxIdentifier="sh.ball.oscirender"
               cppLanguageStandard="20" projectLineFeed="&#10;" headerPath="./include"
-              version="2.0.2" companyName="James H Ball" companyWebsite="https://osci-render.com"
+              version="2.0.3" companyName="James H Ball" companyWebsite="https://osci-render.com"
               companyEmail="james@ball.sh">
   <MAINGROUP id="j5Ge2T" name="osci-render">
     <GROUP id="{5ABCED88-0059-A7AF-9596-DBF91DDB0292}" name="Resources">

--- a/osci-render.jucer
+++ b/osci-render.jucer
@@ -5,7 +5,7 @@
               pluginCharacteristicsValue="pluginProducesMidiOut,pluginWantsMidiIn"
               pluginManufacturer="jameshball" aaxIdentifier="sh.ball.oscirender"
               cppLanguageStandard="20" projectLineFeed="&#10;" headerPath="./include"
-              version="2.0.3" companyName="James H Ball" companyWebsite="https://osci-render.com"
+              version="2.0.4" companyName="James H Ball" companyWebsite="https://osci-render.com"
               companyEmail="james@ball.sh">
   <MAINGROUP id="j5Ge2T" name="osci-render">
     <GROUP id="{5ABCED88-0059-A7AF-9596-DBF91DDB0292}" name="Resources">


### PR DESCRIPTION
- You can now view the software oscilloscope in full-screen by double-clicking it
  - Note, that you can also improve the quality of the oscilloscope by right-clicking and reducing the roughness, though this may lead to worse performance