### PR TITLE
Add sidechain functionality to allow effects to react to audio input volume

### DIFF
--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -610,6 +610,7 @@ void OscirenderAudioProcessor::processBlock(juce::AudioBuffer<float>& buffer, ju
         volumeBuffer[volumeBufferIndex] = (left * left + right * right) / 2;
         squaredVolume += volumeBuffer[volumeBufferIndex] / volumeBuffer.size();
         currentVolume = std::sqrt(squaredVolume);
+        currentVolume = juce::jlimit(0.0, 1.0, currentVolume);
 
         Vector2 channels;
         if (totalNumOutputChannels >= 2) {

--- a/Source/PluginProcessor.h
+++ b/Source/PluginProcessor.h
@@ -336,6 +336,7 @@ private:
 
     std::vector<double> volumeBuffer;
     int volumeBufferIndex = 0;
+    double squaredVolume = 0;
     double currentVolume = 0;
 
     void updateObjValues();

--- a/Source/PluginProcessor.h
+++ b/Source/PluginProcessor.h
@@ -332,6 +332,12 @@ private:
     AudioWebSocketServer softwareOscilloscopeServer{*this};
     ObjectServer objectServer{*this};
 
+    const double VOLUME_BUFFER_SECONDS = 0.1;
+
+    std::vector<double> volumeBuffer;
+    int volumeBufferIndex = 0;
+    double currentVolume = 0;
+
     void updateObjValues();
     std::shared_ptr<Effect> getEffect(juce::String id);
     BooleanParameter* getBooleanParameter(juce::String id);

--- a/Source/audio/Effect.cpp
+++ b/Source/audio/Effect.cpp
@@ -67,7 +67,7 @@ void Effect::animateValues(double volume) {
 			default:
 				double weight = parameter->smoothValueChange ? 0.0005 : 1.0;
 				double newValue;
-				if (parameter->sidechain->getBoolValue()) {
+				if (parameter->sidechain != nullptr && parameter->sidechain->getBoolValue()) {
 					newValue = volume * (maxValue - minValue) + minValue;
 				} else {
                     newValue = parameter->getValueUnnormalised();
@@ -138,11 +138,15 @@ void Effect::addListener(int index, juce::AudioProcessorParameter::Listener* lis
 	if (enabled != nullptr) {
 		enabled->addListener(listener);
 	}
-	parameters[index]->sidechain->addListener(listener);
+	if (parameters[index]->sidechain != nullptr) {
+        parameters[index]->sidechain->addListener(listener);
+    }
 }
 
 void Effect::removeListener(int index, juce::AudioProcessorParameter::Listener* listener) {
-	parameters[index]->sidechain->removeListener(listener);
+	if (parameters[index]->sidechain != nullptr) {
+        parameters[index]->sidechain->removeListener(listener);
+    }
 	if (enabled != nullptr) {
 		enabled->removeListener(listener);
 	}

--- a/Source/audio/Effect.h
+++ b/Source/audio/Effect.h
@@ -5,15 +5,16 @@
 #include "EffectParameter.h"
 #include "BooleanParameter.h"
 
+typedef std::function<Vector2(int index, Vector2 input, const std::vector<double>& values, double sampleRate)> EffectApplicationType;
 
 class Effect {
 public:
 	Effect(std::shared_ptr<EffectApplication> effectApplication, const std::vector<EffectParameter*>& parameters);
 	Effect(std::shared_ptr<EffectApplication> effectApplication, EffectParameter* parameter);
-	Effect(std::function<Vector2(int, Vector2, const std::vector<double>&, double)> application, const std::vector<EffectParameter*>& parameters);
-	Effect(std::function<Vector2(int, Vector2, const std::vector<double>&, double)> application, EffectParameter* parameter);
+	Effect(EffectApplicationType application, const std::vector<EffectParameter*>& parameters);
+	Effect(EffectApplicationType application, EffectParameter* parameter);
 
-	Vector2 apply(int index, Vector2 input);
+	Vector2 apply(int index, Vector2 input, double volume = 0.0);
 	
 	void apply();
 	double getValue(int index);
@@ -43,10 +44,10 @@ private:
 	std::vector<double> actualValues;
 	int precedence = -1;
 	int sampleRate = 192000;
-	std::function<Vector2(int, Vector2, const std::vector<double>&, double)> application;
+	EffectApplicationType application;
 	
 	std::shared_ptr<EffectApplication> effectApplication;
 
-	void animateValues();
+	void animateValues(double volume);
 	float nextPhase(EffectParameter* parameter);
 };

--- a/Source/audio/EffectParameter.h
+++ b/Source/audio/EffectParameter.h
@@ -111,9 +111,6 @@ public:
 
 	// opt to not change any values if not found
 	void load(juce::XmlElement* xml) {
-        if (xml->hasAttribute("value")) {
-			setUnnormalisedValueNotifyingHost(xml->getDoubleAttribute("value"));
-        }
         if (xml->hasAttribute("min")) {
             min = xml->getDoubleAttribute("min");
         }
@@ -123,6 +120,9 @@ public:
         if (xml->hasAttribute("step")) {
             step = xml->getDoubleAttribute("step");
         }
+		if (xml->hasAttribute("value")) {
+			setUnnormalisedValueNotifyingHost(xml->getDoubleAttribute("value"));
+		}
     }
 
 private:
@@ -237,15 +237,15 @@ public:
 
 	// opt to not change any values if not found
 	void load(juce::XmlElement* xml) {
-		if (xml->hasAttribute("value")) {
-            setUnnormalisedValueNotifyingHost(xml->getIntAttribute("value"));
-        }
 		if (xml->hasAttribute("min")) {
             min = xml->getIntAttribute("min");
         }
 		if (xml->hasAttribute("max")) {
             max = xml->getIntAttribute("max");
         }
+		if (xml->hasAttribute("value")) {
+			setUnnormalisedValueNotifyingHost(xml->getIntAttribute("value"));
+		}
     }
 
 private:

--- a/Source/audio/EffectParameter.h
+++ b/Source/audio/EffectParameter.h
@@ -342,7 +342,9 @@ public:
 		if (lfoRate != nullptr) {
 			parameters.push_back(lfoRate);
 		}
-        parameters.push_back(sidechain);
+		if (sidechain != nullptr) {
+			parameters.push_back(sidechain);
+		}
 		return parameters;
     }
 
@@ -353,6 +355,11 @@ public:
 		lfoRate = nullptr;
 	}
 
+	void disableSidechain() {
+        delete sidechain;
+        sidechain = nullptr;
+    }
+
 	void save(juce::XmlElement* xml) {
 		FloatParameter::save(xml);
 
@@ -362,8 +369,10 @@ public:
 			lfoRate->save(lfoXml);
 		}
 
-		auto sidechainXml = xml->createNewChildElement("sidechain");
-		sidechain->save(sidechainXml);
+		if (sidechain != nullptr) {
+			auto sidechainXml = xml->createNewChildElement("sidechain");
+			sidechain->save(sidechainXml);
+		}
     }
 
 	void load(juce::XmlElement* xml) {
@@ -380,11 +389,13 @@ public:
 			}
 		}
 
-		auto sidechainXml = xml->getChildByName("sidechain");
-		if (sidechainXml != nullptr) {
-			sidechain->load(sidechainXml);
-		} else {
-			sidechain->setBoolValueNotifyingHost(false);
+		if (sidechain != nullptr) {
+			auto sidechainXml = xml->getChildByName("sidechain");
+			if (sidechainXml != nullptr) {
+				sidechain->load(sidechainXml);
+			} else {
+				sidechain->setBoolValueNotifyingHost(false);
+			}
 		}
     }
 

--- a/Source/audio/EffectParameter.h
+++ b/Source/audio/EffectParameter.h
@@ -111,7 +111,7 @@ public:
 	// opt to not change any values if not found
 	void load(juce::XmlElement* xml) {
         if (xml->hasAttribute("value")) {
-            value = xml->getDoubleAttribute("value");
+			setUnnormalisedValueNotifyingHost(xml->getDoubleAttribute("value"));
         }
         if (xml->hasAttribute("min")) {
             min = xml->getDoubleAttribute("min");
@@ -237,7 +237,7 @@ public:
 	// opt to not change any values if not found
 	void load(juce::XmlElement* xml) {
 		if (xml->hasAttribute("value")) {
-            value = xml->getIntAttribute("value");
+            setUnnormalisedValueNotifyingHost(xml->getIntAttribute("value"));
         }
 		if (xml->hasAttribute("min")) {
             min = xml->getIntAttribute("min");

--- a/Source/components/EffectComponent.h
+++ b/Source/components/EffectComponent.h
@@ -3,6 +3,7 @@
 #include "../PluginProcessor.h"
 #include "../audio/Effect.h"
 #include "LabelledTextBox.h"
+#include "SvgButton.h"
 
 class EffectComponent : public juce::Component, public juce::AudioProcessorParameter::Listener, juce::AsyncUpdater, public juce::SettableTooltipClient {
 public:
@@ -22,14 +23,22 @@ public:
     juce::Slider slider;
     juce::Slider lfoSlider;
     Effect& effect;
-    int index;
+    int index = 0;
     juce::ComboBox lfo;
 
 private:
+    const int TEXT_BOX_WIDTH = 70;
+    const int SMALL_TEXT_BOX_WIDTH = 50;
+
+    const int TEXT_WIDTH = 120;
+    const int SMALL_TEXT_WIDTH = 60;
+
     void setupComponent();
     bool lfoEnabled = true;
     std::shared_ptr<juce::Component> component;
     OscirenderAudioProcessor& audioProcessor;
+
+    SvgButton sidechainButton{ effect.parameters[index]->name, BinaryData::microphone_svg, "white", "red", effect.parameters[index]->sidechain };
 
     juce::Label popupLabel;
     juce::Label label;

--- a/Source/components/EffectComponent.h
+++ b/Source/components/EffectComponent.h
@@ -35,10 +35,11 @@ private:
 
     void setupComponent();
     bool lfoEnabled = true;
+    bool sidechainEnabled = true;
     std::shared_ptr<juce::Component> component;
     OscirenderAudioProcessor& audioProcessor;
 
-    SvgButton sidechainButton{ effect.parameters[index]->name, BinaryData::microphone_svg, "white", "red", effect.parameters[index]->sidechain };
+    std::unique_ptr<SvgButton> sidechainButton;
 
     juce::Label popupLabel;
     juce::Label label;

--- a/Source/components/EffectsListComponent.cpp
+++ b/Source/components/EffectsListComponent.cpp
@@ -15,7 +15,7 @@ EffectsListComponent::EffectsListComponent(DraggableListBox& lb, AudioEffectList
 				this->effect.setValue(i, effectComponent->slider.getValue());
 			}
 		};
-
+		
 		list.setEnabled(selected.getToggleState());
 		selected.onClick = [this, weakEffectComponent] {
 			if (auto effectComponent = weakEffectComponent.lock()) {
@@ -68,7 +68,7 @@ void EffectsListComponent::paint(juce::Graphics& g) {
 
 void EffectsListComponent::paintOverChildren(juce::Graphics& g) {
 	if (!selected.getToggleState()) {
-        g.setColour(juce::Colours::black.withAlpha(0.5f));
+        g.setColour(juce::Colours::black.withAlpha(0.3f));
 		auto bounds = list.getBounds();
 		bounds.removeFromBottom(2);
 		g.fillRect(bounds);

--- a/osci-render.jucer
+++ b/osci-render.jucer
@@ -5,7 +5,7 @@
               pluginCharacteristicsValue="pluginProducesMidiOut,pluginWantsMidiIn"
               pluginManufacturer="jameshball" aaxIdentifier="sh.ball.oscirender"
               cppLanguageStandard="20" projectLineFeed="&#10;" headerPath="./include"
-              version="2.0.4" companyName="James H Ball" companyWebsite="https://osci-render.com"
+              version="2.0.5" companyName="James H Ball" companyWebsite="https://osci-render.com"
               companyEmail="james@ball.sh">
   <MAINGROUP id="j5Ge2T" name="osci-render">
     <GROUP id="{5ABCED88-0059-A7AF-9596-DBF91DDB0292}" name="Resources">


### PR DESCRIPTION
Demo (unmute audio):

https://github.com/jameshball/osci-render/assets/38670946/e79e63f4-1b7b-4e78-b027-e27e4802f5df

Changes in this version:
- Adds sidechain ability, allowing you to change the value of effects based on the volume of the input audio
  - You can enable this for any slider by clicking the microphone icon next to it
  - When enabled, the microphone icon and slider turn red
  - Now, any audio input controls the value of the effect
  - Closes #189 
- Sliders are now more usable when the interface is made smaller
- When loading a project, the DAW is now properly notified of any changes in values
  - Closes #181 
- Reduce how dark disabled audio effects are, so they are easier to read
  - Closes #190
