### PR TITLE
Fix min/max trace, improve rendering performance, fix dodgy Blender message reading, add button to open MIDI settings

### DIFF
--- a/Source/MidiComponent.cpp
+++ b/Source/MidiComponent.cpp
@@ -38,6 +38,13 @@ MidiComponent::MidiComponent(OscirenderAudioProcessor& p, OscirenderAudioProcess
     envelope.addListener(&audioProcessor);
     envelope.setGrid(EnvelopeComponent::GridBoth, EnvelopeComponent::GridNone, 0.1, 0.25);
 
+    if (juce::JUCEApplicationBase::isStandaloneApp()) {
+        addAndMakeVisible(midiSettingsButton);
+        midiSettingsButton.onClick = [this]() {
+            pluginEditor.openAudioSettings();
+        };
+    }
+
     audioProcessor.attackTime->addListener(this);
     audioProcessor.attackLevel->addListener(this);
     audioProcessor.attackShape->addListener(this);
@@ -105,6 +112,9 @@ void MidiComponent::resized() {
     midiToggle.setBounds(topRow.removeFromLeft(120));
     topRow.removeFromLeft(80);
     voicesSlider.setBounds(topRow.removeFromLeft(250));
+    if (midiSettingsButton.isVisible()) {
+        midiSettingsButton.setBounds(topRow.removeFromRight(160));
+    }
     area.removeFromTop(5);
     keyboard.setBounds(area.removeFromBottom(50));
     envelope.setBounds(area);

--- a/Source/MidiComponent.h
+++ b/Source/MidiComponent.h
@@ -22,6 +22,7 @@ private:
 	juce::ToggleButton midiToggle{"Enable MIDI"};
 	juce::Slider voicesSlider;
 	juce::Label voicesLabel;
+	juce::TextButton midiSettingsButton{"Audio/MIDI Settings..."};
 	juce::MidiKeyboardComponent keyboard{audioProcessor.keyboardState, juce::MidiKeyboardComponent::horizontalKeyboard};
 
 	EnvelopeContainerComponent envelope;

--- a/Source/PluginEditor.cpp
+++ b/Source/PluginEditor.cpp
@@ -58,7 +58,7 @@ OscirenderAudioProcessorEditor::OscirenderAudioProcessorEditor(OscirenderAudioPr
         audioProcessor.broadcaster.addChangeListener(this);
     }
 
-    if (audioProcessor.wrapperType == juce::AudioProcessor::WrapperType::wrapperType_Standalone) {
+    if (juce::JUCEApplicationBase::isStandaloneApp()) {
         if (juce::TopLevelWindow::getNumTopLevelWindows() == 1) {
             juce::TopLevelWindow* w = juce::TopLevelWindow::getTopLevelWindow(0);
             juce::DocumentWindow* dw = dynamic_cast<juce::DocumentWindow*>(w);
@@ -67,6 +67,11 @@ OscirenderAudioProcessorEditor::OscirenderAudioProcessorEditor(OscirenderAudioPr
                 dw->setTitleBarButtonsRequired(juce::DocumentWindow::allButtons, false);
                 dw->setUsingNativeTitleBar(true);
             }
+        }
+
+        juce::StandalonePluginHolder* standalone = juce::StandalonePluginHolder::getInstance();
+        if (standalone != nullptr) {
+            standalone->getMuteInputValue().setValue(false);
         }
     }
 

--- a/Source/audio/ShapeVoice.cpp
+++ b/Source/audio/ShapeVoice.cpp
@@ -148,6 +148,9 @@ void ShapeVoice::renderNextBlock(juce::AudioSampleBuffer& outputBuffer, int star
         if (!renderingSample && frameDrawn >= drawnFrameLength) {
             if (sound.load() != nullptr && currentlyPlaying) {
                 frameLength = sound.load()->updateFrame(frame);
+                frameDrawn = 0.0;
+                shapeDrawn = 0.0;
+                currentShape = 0;
             }
             // TODO: updateFrame already iterates over all the shapes,
             // so we can improve performance by calculating frameDrawn

--- a/Source/obj/ObjectServer.cpp
+++ b/Source/obj/ObjectServer.cpp
@@ -38,9 +38,11 @@ void ObjectServer::run() {
                                 std::memcpy(message.get() + i, buffer, bytesRead);
                                 i += bytesRead;
 
-                                if (message[i] == '\n') {
-                                    message[i] = '\0';
-                                    break;
+                                for (int j = i - bytesRead; j < i; j++) {
+                                    if (message[j] == '\n') {
+                                        message[j] = '\0';
+                                        break;
+                                    }
                                 }
                             }
 

--- a/osci-render.jucer
+++ b/osci-render.jucer
@@ -5,7 +5,7 @@
               pluginCharacteristicsValue="pluginProducesMidiOut,pluginWantsMidiIn"
               pluginManufacturer="jameshball" aaxIdentifier="sh.ball.oscirender"
               cppLanguageStandard="20" projectLineFeed="&#10;" headerPath="./include"
-              version="2.0.7" companyName="James H Ball" companyWebsite="https://osci-render.com"
+              version="2.0.8" companyName="James H Ball" companyWebsite="https://osci-render.com"
               companyEmail="james@ball.sh">
   <MAINGROUP id="j5Ge2T" name="osci-render">
     <GROUP id="{5ABCED88-0059-A7AF-9596-DBF91DDB0292}" name="Resources">


### PR DESCRIPTION
Various bugs and improvements:
- Fixes min trace and max trace effects, so they work as expected
- Improves audio performance
- Fixes a bug that meant osci-render could crash when rendering a Blender scene
- Adds a button to open the Audio and MIDI settings from the MIDI panel when running the standalone version

Closes #211 
Closes #210 