### PR TITLE
Various bug fixes and improvements

### DIFF
--- a/Source/MainComponent.cpp
+++ b/Source/MainComponent.cpp
@@ -112,7 +112,7 @@ MainComponent::MainComponent(OscirenderAudioProcessor& p, OscirenderAudioProcess
 		}
 
 		pluginEditor.addCodeEditor(audioProcessor.getCurrentFileIndex());
-		pluginEditor.fileUpdated(fileName);
+        pluginEditor.fileUpdated(fileName, fileTypeText == ".lua" || fileTypeText == ".txt");
 	};
 
 	fileName.setFont(juce::Font(16.0f, juce::Font::plain));

--- a/Source/PluginEditor.cpp
+++ b/Source/PluginEditor.cpp
@@ -275,13 +275,15 @@ void OscirenderAudioProcessorEditor::removeCodeEditor(int index) {
 
 
 // parsersLock AND effectsLock must be locked before calling this function
-void OscirenderAudioProcessorEditor::updateCodeEditor() {
+void OscirenderAudioProcessorEditor::updateCodeEditor(bool shouldOpenEditor) {
     // check if any code editors are visible
-    bool visible = false;
-    for (int i = 0; i < codeEditors.size(); i++) {
-        if (codeEditors[i]->isVisible()) {
-            visible = true;
-            break;
+    bool visible = shouldOpenEditor;
+    if (!visible) {
+        for (int i = 0; i < codeEditors.size(); i++) {
+            if (codeEditors[i]->isVisible()) {
+                visible = true;
+                break;
+            }
         }
     }
     int originalIndex = audioProcessor.getCurrentFileIndex();
@@ -307,9 +309,9 @@ void OscirenderAudioProcessorEditor::updateCodeEditor() {
 }
 
 // parsersLock MUST be locked before calling this function
-void OscirenderAudioProcessorEditor::fileUpdated(juce::String fileName) {
+void OscirenderAudioProcessorEditor::fileUpdated(juce::String fileName, bool shouldOpenEditor) {
     settings.fileUpdated(fileName);
-    updateCodeEditor();
+    updateCodeEditor(shouldOpenEditor);
 }
 
 void OscirenderAudioProcessorEditor::handleAsyncUpdate() {

--- a/Source/PluginEditor.cpp
+++ b/Source/PluginEditor.cpp
@@ -356,8 +356,8 @@ void OscirenderAudioProcessorEditor::editCustomFunction(bool enable) {
     editingCustomFunction = enable;
     juce::SpinLock::ScopedLockType lock1(audioProcessor.parsersLock);
     juce::SpinLock::ScopedLockType lock2(audioProcessor.effectsLock);
-    updateCodeEditor();
     codeEditors[0]->setVisible(enable);
+    updateCodeEditor();
 }
 
 // parsersLock AND effectsLock must be locked before calling this function

--- a/Source/PluginEditor.h
+++ b/Source/PluginEditor.h
@@ -21,7 +21,7 @@ public:
     void initialiseCodeEditors();
     void addCodeEditor(int index);
     void removeCodeEditor(int index);
-    void fileUpdated(juce::String fileName);
+    void fileUpdated(juce::String fileName, bool shouldOpenEditor = false);
     void handleAsyncUpdate() override;
     void changeListenerCallback(juce::ChangeBroadcaster* source) override;
     void toggleLayout(juce::StretchableLayoutManager& layout, double prefSize);
@@ -90,7 +90,7 @@ public:
 	void codeDocumentTextInserted(const juce::String& newText, int insertIndex) override;
 	void codeDocumentTextDeleted(int startIndex, int endIndex) override;
     void updateCodeDocument();
-    void updateCodeEditor();
+    void updateCodeEditor(bool shouldOpenEditor = false);
 
     bool keyPressed(const juce::KeyPress& key) override;
     void mouseDown(const juce::MouseEvent& event) override;

--- a/Source/components/DraggableListBox.cpp
+++ b/Source/components/DraggableListBox.cpp
@@ -74,6 +74,7 @@ void DraggableListBoxItem::itemDragExit(const SourceDetails& /*dragSourceDetails
 
 void DraggableListBoxItem::itemDropped(const juce::DragAndDropTarget::SourceDetails &dragSourceDetails)
 {
+    hideInsertLines();
     if (DraggableListBoxItem* item = dynamic_cast<DraggableListBoxItem*>(dragSourceDetails.sourceComponent.get()))
     {
         if (dragSourceDetails.localPosition.y < getHeight() / 2)
@@ -82,7 +83,6 @@ void DraggableListBoxItem::itemDropped(const juce::DragAndDropTarget::SourceDeta
             modelData.moveAfter(item->rowNum, rowNum);
         listBox.updateContent();
     }
-    hideInsertLines();
 }
 
 juce::Component* DraggableListBoxModel::refreshComponentForRow(int rowNumber, bool isRowSelected, juce::Component *existingComponentToUpdate)

--- a/Source/components/EffectComponent.cpp
+++ b/Source/components/EffectComponent.cpp
@@ -8,9 +8,9 @@ EffectComponent::EffectComponent(OscirenderAudioProcessor& p, Effect& effect, in
     addAndMakeVisible(label);
     addAndMakeVisible(rangeButton);
 
-    sidechainEnabled = effect.parameters[0]->sidechain != nullptr;
+    sidechainEnabled = effect.parameters[index]->sidechain != nullptr;
     if (sidechainEnabled) {
-        sidechainButton = std::make_unique<SvgButton>(effect.parameters[0]->name, BinaryData::microphone_svg, juce::Colours::white, juce::Colours::red, effect.parameters[0]->sidechain);
+        sidechainButton = std::make_unique<SvgButton>(effect.parameters[index]->name, BinaryData::microphone_svg, juce::Colours::white, juce::Colours::red, effect.parameters[index]->sidechain);
         sidechainButton->setTooltip("When enabled, the volume of the input audio controls the value of the slider, acting like a sidechain effect.");
         addAndMakeVisible(*sidechainButton);
     }

--- a/osci-render.jucer
+++ b/osci-render.jucer
@@ -637,7 +637,7 @@
                bigIcon="pSc1mq" applicationCategory="public.app-category.music">
       <CONFIGURATIONS>
         <CONFIGURATION isDebug="1" name="Debug" targetName="osci-render"/>
-        <CONFIGURATION isDebug="0" name="Release" targetName="osci-render"/>
+        <CONFIGURATION isDebug="1" name="Release" targetName="osci-render"/>
       </CONFIGURATIONS>
       <MODULEPATHS>
         <MODULEPATH id="juce_audio_basics" path="../../../JUCE/modules"/>

--- a/osci-render.jucer
+++ b/osci-render.jucer
@@ -2,11 +2,11 @@
 
 <JUCERPROJECT id="HH2E72" name="osci-render" projectType="audioplug" useAppConfig="0"
               addUsingNamespaceToJuceHeader="0" displaySplashScreen="0" jucerFormatVersion="1"
-              pluginCharacteristicsValue="pluginProducesMidiOut,pluginWantsMidiIn"
-              pluginManufacturer="jameshball" aaxIdentifier="sh.ball.oscirender"
-              cppLanguageStandard="20" projectLineFeed="&#10;" headerPath="./include"
-              version="2.1.5" companyName="James H Ball" companyWebsite="https://osci-render.com"
-              companyEmail="james@ball.sh" defines="NOMINMAX=1">
+              pluginCharacteristicsValue="pluginWantsMidiIn" pluginManufacturer="jameshball"
+              aaxIdentifier="sh.ball.oscirender" cppLanguageStandard="20" projectLineFeed="&#10;"
+              headerPath="./include" version="2.1.6" companyName="James H Ball"
+              companyWebsite="https://osci-render.com" companyEmail="james@ball.sh"
+              defines="NOMINMAX=1" pluginAUMainType="'aumu'">
   <MAINGROUP id="j5Ge2T" name="osci-render">
     <GROUP id="{5ABCED88-0059-A7AF-9596-DBF91DDB0292}" name="Resources">
       <GROUP id="{C2609827-4F4A-1ADA-8BA1-A40C1D92649C}" name="lua">


### PR DESCRIPTION
- Fixed bug where custom Lua effect code would be blank when opening and closing a VST window
- Fixed bug where enabling sidechain on the first parameter in an effect causes sidechain on all parameters to be enabled
- Fixed crash when reordering effects
- Changed AU plugin type so it appears correctly as an instrument in GarageBand
- Osci-render now automatically opens the code editor when a Lua or text file is created

Closes #231 #230 