### PR TITLE
Update __init__.py to work in Blender 4.3

### DIFF
--- a/blender/osci_render/__init__.py
+++ b/blender/osci_render/__init__.py
@@ -127,7 +127,7 @@ def append_matrix(object_info, obj):
 
 def get_frame_info():
     frame_info = {"objects": []}    
-    if (bpy.app.version[0] >= 4 and bpy.app.version[1] >= 3):
+    if (bpy.app.version[0] > 4) or (bpy.app.version[0] == 4 and bpy.app.version[1] >= 3):
         for obj in bpy.data.objects:
             if obj.visible_get() and obj.type == 'GREASEPENCIL':                
                 object_info = {"name": obj.name}

--- a/blender/osci_render/__init__.py
+++ b/blender/osci_render/__init__.py
@@ -1,7 +1,7 @@
 bl_info = {
     "name": "osci-render",
     "author": "James Ball", 
-    "version": (1, 0, 2),
+    "version": (1, 0, 3),
     "blender": (3, 1, 2),
     "location": "View3D",
     "description": "Addon to send gpencil frames over to osci-render",

--- a/blender/osci_render/blender_manifest.toml
+++ b/blender/osci_render/blender_manifest.toml
@@ -1,0 +1,18 @@
+schema_version = "1.0.0"
+
+id = "osci_render"
+version = "1.0.3"
+name = "osci-render"
+tagline = "Addon to send gpencil frames over to osci-render"
+maintainer = "James H. Ball <https://github.com/jameshball>"
+type = "add-on"
+
+website = "https://github.com/jameshball/osci-render"
+
+tags = ["Animation", "Bake", "Grease Pencil", "Import-Export", "Render"]
+
+blender_version_min = "4.2.0"
+
+license = [
+  "SPDX:GPL-3.0-or-later",
+]


### PR DESCRIPTION
It looks like they've rolled back (or at least reduced the stringency of) the requirement to supply blender_manifest.toml with the plugin! Therefore, this PR only contains the required code changes to get the plugin working in 4.3.