### PR TITLE
v2.4.11.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ ci/sign.sh
 
 .DS_Store
 
+.vscode
+
 *.pkg
 *.psd
 *.xcf

--- a/Source/CommonPluginEditor.cpp
+++ b/Source/CommonPluginEditor.cpp
@@ -61,6 +61,8 @@ CommonPluginEditor::CommonPluginEditor(CommonAudioProcessor& p, juce::String app
     setResizeLimits(250, 250, 999999, 999999);
 
     tooltipDropShadow.setOwner(&tooltipWindow);
+    
+    updateTitle();
 
 #if SOSCI_FEATURES
     sharedTextureManager.initGL();
@@ -179,5 +181,6 @@ void CommonPluginEditor::resetToDefault() {
     juce::StandaloneFilterWindow* window = findParentComponentOfClass<juce::StandaloneFilterWindow>();
     if (window != nullptr) {
         window->resetToDefaultState();
+        window->setName(ProjectInfo::projectName);
     }
 }

--- a/Source/CommonPluginEditor.cpp
+++ b/Source/CommonPluginEditor.cpp
@@ -155,7 +155,15 @@ void CommonPluginEditor::updateTitle() {
     if (!audioProcessor.currentProjectFile.isEmpty()) {
         title += " - " + audioProcessor.currentProjectFile;
     }
+    if (currentFileName.isNotEmpty()) {
+        title += " - " + currentFileName;
+    }
     getTopLevelComponent()->setName(title);
+}
+
+void CommonPluginEditor::fileUpdated(juce::String fileName) {
+    currentFileName = fileName;
+    updateTitle();
 }
 
 void CommonPluginEditor::openAudioSettings() {

--- a/Source/CommonPluginEditor.cpp
+++ b/Source/CommonPluginEditor.cpp
@@ -46,8 +46,7 @@ CommonPluginEditor::CommonPluginEditor(CommonAudioProcessor& p, juce::String app
     visualiserSettings.setColour(juce::ResizableWindow::backgroundColourId, Colours::dark);
 
     recordingSettings.setLookAndFeel(&getLookAndFeel());
-    recordingSettings.setSize(350, 280);
-    recordingSettingsWindow.centreWithSize(350, 320);
+    recordingSettings.setSize(300, 280);
 #if JUCE_WINDOWS
     // if not standalone, use native title bar for compatibility with DAWs
     recordingSettingsWindow.setUsingNativeTitleBar(processor.wrapperType == juce::AudioProcessor::WrapperType::wrapperType_Standalone);

--- a/Source/CommonPluginEditor.h
+++ b/Source/CommonPluginEditor.h
@@ -52,14 +52,14 @@ public:
 #endif
 
 #if SOSCI_FEATURES
-    int VISUALISER_SETTINGS_HEIGHT = 1250;
+    int VISUALISER_SETTINGS_HEIGHT = 1200;
 #else
-    int VISUALISER_SETTINGS_HEIGHT = 800;
+    int VISUALISER_SETTINGS_HEIGHT = 700;
 #endif
 
     VisualiserSettings visualiserSettings = VisualiserSettings(audioProcessor.visualiserParameters, 3);
     RecordingSettings recordingSettings = RecordingSettings(audioProcessor.recordingParameters);
-    SettingsWindow recordingSettingsWindow = SettingsWindow("Recording Settings", recordingSettings);
+    SettingsWindow recordingSettingsWindow = SettingsWindow("Recording Settings", recordingSettings, 300, 320, 300, 320);
     VisualiserComponent visualiser{
         audioProcessor,
 #if SOSCI_FEATURES

--- a/Source/CommonPluginEditor.h
+++ b/Source/CommonPluginEditor.h
@@ -20,6 +20,7 @@ public:
     void saveProject();
     void saveProjectAs();
     void updateTitle();
+    void fileUpdated(juce::String fileName);
     void openAudioSettings();
     void openRecordingSettings();
     void resetToDefault();
@@ -46,6 +47,7 @@ public:
 
     juce::String appName;
     juce::String projectFileType;
+    juce::String currentFileName;
     
 #if SOSCI_FEATURES
     SharedTextureManager sharedTextureManager;

--- a/Source/CommonPluginEditor.h
+++ b/Source/CommonPluginEditor.h
@@ -61,7 +61,7 @@ public:
 
     VisualiserSettings visualiserSettings = VisualiserSettings(audioProcessor.visualiserParameters, 3);
     RecordingSettings recordingSettings = RecordingSettings(audioProcessor.recordingParameters);
-    SettingsWindow recordingSettingsWindow = SettingsWindow("Recording Settings", recordingSettings, 300, 320, 300, 320);
+    SettingsWindow recordingSettingsWindow = SettingsWindow("Recording Settings", recordingSettings, 330, 320, 330, 320);
     VisualiserComponent visualiser{
         audioProcessor,
 #if SOSCI_FEATURES

--- a/Source/LookAndFeel.cpp
+++ b/Source/LookAndFeel.cpp
@@ -396,7 +396,7 @@ void OscirenderLookAndFeel::drawCallOutBoxBackground(juce::CallOutBox& box, juce
     g.setColour(juce::Colours::black);
     g.drawImageAt(cachedImage, 0, 0);
 
-    g.setColour(Colours::dark);
+    g.setColour(Colours::darker);
     g.fillPath(path);
 
     g.setColour(juce::Colours::black);

--- a/Source/PluginEditor.cpp
+++ b/Source/PluginEditor.cpp
@@ -359,6 +359,7 @@ void OscirenderAudioProcessorEditor::updateCodeEditor(bool binaryFile, bool shou
 
 // parsersLock MUST be locked before calling this function
 void OscirenderAudioProcessorEditor::fileUpdated(juce::String fileName, bool shouldOpenEditor) {
+    CommonPluginEditor::fileUpdated(fileName);
     settings.fileUpdated(fileName);
     updateCodeEditor(isBinaryFile(fileName), shouldOpenEditor);
 }

--- a/Source/PluginEditor.h
+++ b/Source/PluginEditor.h
@@ -51,7 +51,7 @@ public:
     juce::ComponentAnimator codeEditorAnimator;
     LuaComponent lua{audioProcessor, *this};
 
-    SettingsWindow visualiserSettingsWindow = SettingsWindow("Visualiser Settings", visualiserSettings);
+    SettingsWindow visualiserSettingsWindow = SettingsWindow("Visualiser Settings", visualiserSettings, 550, 500, 550, VISUALISER_SETTINGS_HEIGHT);
 
     LuaConsole console;
 

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -226,7 +226,7 @@ void OscirenderAudioProcessor::addLuaSlider() {
             "Lua Slider " + sliderName,
             "Controls the value of the Lua variable called slider_" + sliderName.toLowerCase() + ".",
             "lua" + sliderName,
-            VERSION_HINT, 0.0, 0.0, 1.0, 0.001, false
+            VERSION_HINT, 0.0, 0.0, 1.0
         )
     ));
 }

--- a/Source/PluginProcessor.h
+++ b/Source/PluginProcessor.h
@@ -77,13 +77,13 @@ public:
                 "Trace Start",
                 "Defines how far into the frame the drawing is started at. This has the effect of 'tracing' out the image from a single dot when animated. By default, we start drawing from the beginning of the frame, so this value is 0.0.",
                 "traceStart",
-                VERSION_HINT, 0.0, 0.0, 1.0, 0.001, 0.001
+                VERSION_HINT, 0.0, 0.0, 1.0, 0.001
             ),
             new EffectParameter(
                 "Trace Length",
                 "Defines how much of the frame is drawn per cycle. This has the effect of 'tracing' out the image from a single dot when animated. By default, we draw the whole frame, corresponding to a value of 1.0.",
                 "traceLength",
-                VERSION_HINT, 1.0, 0.0, 1.0, 0.001, 0.001
+                VERSION_HINT, 1.0, 0.0, 1.0, 0.001
             ),
         }
     );
@@ -170,7 +170,7 @@ public:
             "Image Stride",
             "Controls the spacing between pixels when drawing an image. Larger values mean more of the image can be drawn, but at a lower fidelity.",
             "imageStride",
-            VERSION_HINT, 4, 1, 50, 1, false
+            VERSION_HINT, 4, 1, 50, 1
         )
     );
 

--- a/Source/audio/Effect.cpp
+++ b/Source/audio/Effect.cpp
@@ -75,17 +75,20 @@ void Effect::animateValues(double volume) {
 				actualValues[i] = ((float)rand() / RAND_MAX) * (maxValue - minValue) + minValue;
 				break;
 			default:
-                double weight = 1.0;
-                if (parameter->smoothValueChange < 1.0 && parameter->smoothValueChange > SMOOTHING_SPEED_MIN) {
-                    weight = parameter->smoothValueChange.load() * 192000 / sampleRate;
-                }
+                double smoothValueChange = juce::jlimit(SMOOTHING_SPEED_MIN, 1.0, parameter->smoothValueChange.load());
+                smoothValueChange /= 1000;
+                double weight = smoothValueChange * 192000 / sampleRate;
 				double newValue;
 				if (parameter->sidechain != nullptr && parameter->sidechain->getBoolValue()) {
 					newValue = volume * (maxValue - minValue) + minValue;
 				} else {
                     newValue = parameter->getValueUnnormalised();
                 }
-				actualValues[i] = (1.0 - weight) * actualValues[i] + weight * newValue;
+                if (parameter->smoothValueChange.load() >= 1.0) {
+                    actualValues[i] = newValue;
+                } else {
+                    actualValues[i] = (1.0 - weight) * actualValues[i] + weight * newValue;
+                }
 				break;
 		}
 	}

--- a/Source/audio/Effect.cpp
+++ b/Source/audio/Effect.cpp
@@ -36,10 +36,16 @@ void Effect::animateValues(double volume) {
 		auto parameter = parameters[i];
 		float minValue = parameter->min;
 		float maxValue = parameter->max;
-		bool lfoEnabled = parameter->lfo != nullptr && parameter->lfo->getValueUnnormalised() != (int)LfoType::Static;
+        bool lfoEnabled = parameter->isLfoEnabled() && parameter->lfo->getValueUnnormalised() != (int)LfoType::Static;
 		float phase = lfoEnabled ? nextPhase(parameter) : 0.0;
 		float percentage = phase / (2 * std::numbers::pi);
 		LfoType type = lfoEnabled ? (LfoType)(int)parameter->lfo->getValueUnnormalised() : LfoType::Static;
+        
+        if (lfoEnabled) {
+            double originalMin = minValue;
+            minValue = originalMin + (parameter->lfoStartPercent->getValueUnnormalised() / 100.0) * (maxValue - originalMin);
+            maxValue = originalMin + (parameter->lfoEndPercent->getValueUnnormalised() / 100.0) * (maxValue - originalMin);
+        }
 
 		switch (type) {
 			case LfoType::Sine:

--- a/Source/audio/EffectParameter.h
+++ b/Source/audio/EffectParameter.h
@@ -448,7 +448,7 @@ public:
         return lfoEnabled;
     }
 
-    EffectParameter(juce::String name, juce::String description, juce::String id, int versionHint, float value, float min, float max, float step = 0.0001, double smoothValueChange = SMOOTHING_SPEED_CONSTANT) : FloatParameter(name, id, versionHint, value, min, max, step), smoothValueChange(smoothValueChange), description(description) {}
+    EffectParameter(juce::String name, juce::String description, juce::String id, int versionHint, float value, float min, float max, float step = 0.0001) : FloatParameter(name, id, versionHint, value, min, max, step), description(description) {}
     
 private:
     bool lfoEnabled = true;

--- a/Source/audio/EffectParameter.h
+++ b/Source/audio/EffectParameter.h
@@ -3,8 +3,8 @@
 #include <JuceHeader.h>
 #include "BooleanParameter.h"
 
-#define SMOOTHING_SPEED_CONSTANT 0.0003
-#define SMOOTHING_SPEED_MIN 0.0001
+#define SMOOTHING_SPEED_CONSTANT 0.3
+#define SMOOTHING_SPEED_MIN 0.00001
 
 class FloatParameter : public juce::AudioProcessorParameterWithID {
 public:
@@ -383,6 +383,7 @@ public:
 
 	void save(juce::XmlElement* xml) {
 		FloatParameter::save(xml);
+		xml->setAttribute("smoothValueChange", smoothValueChange.load());
 
 		if (lfoEnabled) {
 			auto lfoXml = xml->createNewChildElement("lfo");
@@ -402,6 +403,11 @@ public:
 
 	void load(juce::XmlElement* xml) {
         FloatParameter::load(xml);
+		if (xml->hasAttribute("smoothValueChange")) {
+			smoothValueChange = xml->getDoubleAttribute("smoothValueChange");
+        } else {
+            smoothValueChange = SMOOTHING_SPEED_CONSTANT;
+        }
 
 		if (lfoEnabled) {
 			auto lfoXml = xml->getChildByName("lfo");

--- a/Source/components/EffectComponent.cpp
+++ b/Source/components/EffectComponent.cpp
@@ -6,7 +6,7 @@ EffectComponent::EffectComponent(Effect& effect, int index) : effect(effect), in
     addChildComponent(lfoSlider);
     addAndMakeVisible(lfo);
     addAndMakeVisible(label);
-    addAndMakeVisible(rangeButton);
+    addAndMakeVisible(settingsButton);
 
     sidechainEnabled = effect.parameters[index]->sidechain != nullptr;
     if (sidechainEnabled) {
@@ -40,12 +40,13 @@ EffectComponent::EffectComponent(Effect& effect, int index) : effect(effect), in
     lfo.addItem("Reverse Sawtooth", static_cast<int>(LfoType::ReverseSawtooth));
     lfo.addItem("Noise", static_cast<int>(LfoType::Noise));
 
-    rangeButton.setTooltip("Click to change the range of the slider.");
+    settingsButton.setTooltip("Click to change the slider settings, including range.");
 
-    rangeButton.onClick = [this] {
-        auto range = std::make_unique<EffectRangeComponent>(this);
-        range->setSize(200, 110);
-        auto& myBox = juce::CallOutBox::launchAsynchronously(std::move(range), rangeButton.getScreenBounds(), nullptr);
+    settingsButton.onClick = [this] {
+        auto settings = std::make_unique<EffectSettingsComponent>(this);
+        settings->setLookAndFeel(&getLookAndFeel());
+        settings->setSize(200, 220);
+        auto& myBox = juce::CallOutBox::launchAsynchronously(std::move(settings), settingsButton.getScreenBounds(), nullptr);
     };
 
     effect.addListener(index, this);
@@ -152,6 +153,10 @@ void EffectComponent::resized() {
     if (sidechainEnabled) {
         sidechainButton->setBounds(bounds.removeFromRight(20));
     }
+    
+    if (settingsButton.isVisible()) {
+        settingsButton.setBounds(bounds.removeFromRight(20));
+    }
 
     bool drawingSmall = bounds.getWidth() < 3.5 * TEXT_WIDTH;
 
@@ -159,10 +164,8 @@ void EffectComponent::resized() {
         lfo.setBounds(bounds.removeFromRight(drawingSmall ? 70 : 100).reduced(0, 5));
     }
 
-    if (rangeButton.isVisible()) {
-        rangeButton.setBounds(bounds.removeFromRight(20));
-    }   
-
+    bounds.removeFromRight(2);
+    
     bounds.removeFromLeft(5);
 
     label.setBounds(bounds.removeFromLeft(drawingSmall ? SMALL_TEXT_WIDTH : TEXT_WIDTH));
@@ -198,7 +201,7 @@ void EffectComponent::handleAsyncUpdate() {
 }
 
 void EffectComponent::setRangeEnabled(bool enabled) {
-    rangeButton.setVisible(enabled);
+    settingsButton.setVisible(enabled);
 }
 
 void EffectComponent::setComponent(std::shared_ptr<juce::Component> component) {

--- a/Source/components/EffectComponent.cpp
+++ b/Source/components/EffectComponent.cpp
@@ -45,7 +45,7 @@ EffectComponent::EffectComponent(Effect& effect, int index) : effect(effect), in
     settingsButton.onClick = [this] {
         auto settings = std::make_unique<EffectSettingsComponent>(this);
         settings->setLookAndFeel(&getLookAndFeel());
-        settings->setSize(200, 220);
+        settings->setSize(200, 290);
         auto& myBox = juce::CallOutBox::launchAsynchronously(std::move(settings), settingsButton.getScreenBounds(), nullptr);
     };
 

--- a/Source/components/EffectComponent.h
+++ b/Source/components/EffectComponent.h
@@ -37,6 +37,8 @@ public:
             addAndMakeVisible(lfoEndLabel);
             addAndMakeVisible(lfoStartSlider);
             addAndMakeVisible(lfoEndSlider);
+            addAndMakeVisible(smoothValueChangeLabel);
+            addAndMakeVisible(smoothValueChangeSlider);
             
             EffectParameter* parameter = parent->effect.parameters[parent->index];
             
@@ -86,6 +88,16 @@ public:
             lfoEndSlider.onValueChange = [this, parameter]() {
                 parameter->lfoEndPercent->setUnnormalisedValueNotifyingHost(lfoEndSlider.getValue());
             };
+            
+            smoothValueChangeLabel.setText("Smooth Value Change Speed", juce::dontSendNotification);
+            smoothValueChangeLabel.setJustificationType(juce::Justification::centred);
+            smoothValueChangeLabel.setFont(juce::Font(14.0f, juce::Font::bold));
+
+            smoothValueChangeSlider.setRange(0.01, 1.0, 0.0001);
+            smoothValueChangeSlider.setValue(parameter->smoothValueChange, juce::dontSendNotification);
+            smoothValueChangeSlider.onValueChange = [this, parameter]() {
+                parameter->smoothValueChange = smoothValueChangeSlider.getValue();
+            };
 
             popupLabel.setText(parameter->name + " Range", juce::dontSendNotification);
             popupLabel.setJustificationType(juce::Justification::centred);
@@ -101,6 +113,8 @@ public:
             lfoStartSlider.setBounds(bounds.removeFromTop(40));
             lfoEndLabel.setBounds(bounds.removeFromTop(20));
             lfoEndSlider.setBounds(bounds.removeFromTop(40));
+            smoothValueChangeLabel.setBounds(bounds.removeFromTop(20));
+            smoothValueChangeSlider.setBounds(bounds.removeFromTop(40));
         }
         
     private:
@@ -111,6 +125,8 @@ public:
         juce::Label lfoEndLabel;
         juce::Slider lfoStartSlider;
         juce::Slider lfoEndSlider;
+        juce::Label smoothValueChangeLabel;
+        juce::Slider smoothValueChangeSlider;
     };
     
     std::function<void()> updateToggleState;

--- a/Source/components/EffectComponent.h
+++ b/Source/components/EffectComponent.h
@@ -27,12 +27,16 @@ public:
     int index = 0;
     juce::ComboBox lfo;
     
-    class EffectRangeComponent : public juce::Component {
+    class EffectSettingsComponent : public juce::Component {
     public:
-        EffectRangeComponent(EffectComponent* parent) {
+        EffectSettingsComponent(EffectComponent* parent) {
             addAndMakeVisible(popupLabel);
             addAndMakeVisible(min);
             addAndMakeVisible(max);
+            addAndMakeVisible(lfoStartLabel);
+            addAndMakeVisible(lfoEndLabel);
+            addAndMakeVisible(lfoStartSlider);
+            addAndMakeVisible(lfoEndSlider);
             
             EffectParameter* parameter = parent->effect.parameters[parent->index];
             
@@ -61,6 +65,28 @@ public:
                 parent->slider.setRange(parameter->min, parameter->max, parameter->step);
             };
 
+            lfoStartLabel.setText("LFO Start", juce::dontSendNotification);
+            lfoStartLabel.setJustificationType(juce::Justification::centred);
+            lfoStartLabel.setFont(juce::Font(14.0f, juce::Font::bold));
+
+            lfoEndLabel.setText("LFO End", juce::dontSendNotification);
+            lfoEndLabel.setJustificationType(juce::Justification::centred);
+            lfoEndLabel.setFont(juce::Font(14.0f, juce::Font::bold));
+
+            lfoStartSlider.setRange(parameter->lfoStartPercent->min, parameter->lfoStartPercent->max, parameter->lfoStartPercent->step);
+            lfoStartSlider.setValue(parameter->lfoStartPercent->getValueUnnormalised(), juce::dontSendNotification);
+            lfoStartSlider.setTextValueSuffix("%");
+            lfoStartSlider.onValueChange = [this, parameter]() {
+                parameter->lfoStartPercent->setUnnormalisedValueNotifyingHost(lfoStartSlider.getValue());
+            };
+
+            lfoEndSlider.setRange(parameter->lfoEndPercent->min, parameter->lfoEndPercent->max, parameter->lfoEndPercent->step);
+            lfoEndSlider.setValue(parameter->lfoEndPercent->getValueUnnormalised(), juce::dontSendNotification);
+            lfoEndSlider.setTextValueSuffix("%");
+            lfoEndSlider.onValueChange = [this, parameter]() {
+                parameter->lfoEndPercent->setUnnormalisedValueNotifyingHost(lfoEndSlider.getValue());
+            };
+
             popupLabel.setText(parameter->name + " Range", juce::dontSendNotification);
             popupLabel.setJustificationType(juce::Justification::centred);
             popupLabel.setFont(juce::Font(14.0f, juce::Font::bold));
@@ -71,12 +97,20 @@ public:
             popupLabel.setBounds(bounds.removeFromTop(30));
             min.setBounds(bounds.removeFromTop(40));
             max.setBounds(bounds.removeFromTop(40));
+            lfoStartLabel.setBounds(bounds.removeFromTop(20));
+            lfoStartSlider.setBounds(bounds.removeFromTop(40));
+            lfoEndLabel.setBounds(bounds.removeFromTop(20));
+            lfoEndSlider.setBounds(bounds.removeFromTop(40));
         }
         
     private:
         juce::Label popupLabel;
         LabelledTextBox min{"Min"};
         LabelledTextBox max{"Max"};
+        juce::Label lfoStartLabel;
+        juce::Label lfoEndLabel;
+        juce::Slider lfoStartSlider;
+        juce::Slider lfoEndSlider;
     };
     
     std::function<void()> updateToggleState;
@@ -98,7 +132,7 @@ private:
 
     juce::Label label;
 
-    SvgButton rangeButton = { "rangeButton", BinaryData::range_svg, juce::Colours::white };
+    SvgButton settingsButton = { "settingsButton", BinaryData::cog_svg, juce::Colours::white };
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(EffectComponent)
 };

--- a/Source/visualiser/VisualiserComponent.cpp
+++ b/Source/visualiser/VisualiserComponent.cpp
@@ -885,7 +885,7 @@ void VisualiserComponent::setupTextures() {
 
 Texture VisualiserComponent::makeTexture(int width, int height, GLuint textureID) {
     using namespace juce::gl;
-    
+
     // replace existing texture if it exists, otherwise create new texture
     if (textureID == 0) {
         glGenTextures(1, &textureID);
@@ -900,17 +900,28 @@ Texture VisualiserComponent::makeTexture(int width, int height, GLuint textureID
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_BORDER);
     float borderColor[] = { 0.0f, 0.0f, 0.0f, 1.0f };
     glTexParameterfv(GL_TEXTURE_2D, GL_TEXTURE_BORDER_COLOR, borderColor);
-    
+
+    glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, textureID, 0);
+    glViewport(0, 0, width, height);
+
+    // Clear it once so we don't see uninitialized pixels
+    glClearColor(0, 0, 0, 0);
+    glClear(GL_COLOR_BUFFER_BIT);
+
     glBindTexture(GL_TEXTURE_2D, 0); // Unbind
-    
+
     return { textureID, width, height };
 }
 
 void VisualiserComponent::setResolution(int width) {
     using namespace juce::gl;
-    
+
+    glBindFramebuffer(GL_FRAMEBUFFER, frameBuffer);
+
     lineTexture = makeTexture(width, width, lineTexture.id);
     renderTexture = makeTexture(width, width, renderTexture.id);
+
+    glBindFramebuffer(GL_FRAMEBUFFER, 0); // Unbind
 }
 
 void VisualiserComponent::drawLineTexture(const std::vector<float>& xPoints, const std::vector<float>& yPoints, const std::vector<float>& zPoints) {

--- a/Source/visualiser/VisualiserSettings.h
+++ b/Source/visualiser/VisualiserSettings.h
@@ -548,10 +548,10 @@ private:
 
 class SettingsWindow : public juce::DialogWindow {
 public:
-    SettingsWindow(juce::String name, juce::Component& component) : juce::DialogWindow(name, Colours::darker, true, true), component(component) {
+    SettingsWindow(juce::String name, juce::Component& component, int windowWidth, int windowHeight, int componentWidth, int componentHeight) : juce::DialogWindow(name, Colours::darker, true, true), component(component) {
         setContentComponent(&viewport);
-        centreWithSize(550, 500);
-        setResizeLimits(getWidth(), 300, getWidth(), 1080);
+        centreWithSize(windowWidth, windowHeight);
+        setResizeLimits(windowWidth, windowHeight, componentWidth, componentHeight);
         setResizable(true, false);
         viewport.setColour(juce::ScrollBar::trackColourId, juce::Colours::white);
         viewport.setViewedComponent(&component, false);

--- a/osci-render.jucer
+++ b/osci-render.jucer
@@ -4,7 +4,7 @@
               addUsingNamespaceToJuceHeader="0" jucerFormatVersion="1" pluginCharacteristicsValue="pluginWantsMidiIn"
               pluginManufacturer="jameshball" aaxIdentifier="sh.ball.oscirender"
               cppLanguageStandard="20" projectLineFeed="&#10;" headerPath="./include"
-              version="2.4.10.3" companyName="James H Ball" companyWebsite="https://osci-render.com"
+              version="2.4.11.0" companyName="James H Ball" companyWebsite="https://osci-render.com"
               companyEmail="james@ball.sh" defines="NOMINMAX=1&#10;INTERNET_FLAG_NO_AUTO_REDIRECT=0&#10;SOSCI_FEATURES=1&#10;JUCE_USE_CUSTOM_PLUGIN_STANDALONE_APP=1"
               pluginAUMainType="'aumf'">
   <MAINGROUP id="j5Ge2T" name="osci-render">

--- a/osci-render.jucer
+++ b/osci-render.jucer
@@ -720,7 +720,7 @@
     </GROUP>
   </MAINGROUP>
   <JUCEOPTIONS JUCE_STRICT_REFCOUNTEDPOINTER="1" JUCE_VST3_CAN_REPLACE_VST2="0"
-               JUCE_WIN_PER_MONITOR_DPI_AWARE="0" JUCE_WEB_BROWSER="0"/>
+               JUCE_WEB_BROWSER="0"/>
   <EXPORTFORMATS>
     <LINUX_MAKE targetFolder="Builds/osci-render/LinuxMakefile" smallIcon="pSc1mq"
                 bigIcon="pSc1mq">

--- a/sosci.jucer
+++ b/sosci.jucer
@@ -225,7 +225,7 @@
     </GROUP>
   </MAINGROUP>
   <JUCEOPTIONS JUCE_STRICT_REFCOUNTEDPOINTER="1" JUCE_VST3_CAN_REPLACE_VST2="0"
-               JUCE_WIN_PER_MONITOR_DPI_AWARE="0" JUCE_WEB_BROWSER="0" JUCE_USE_MP3AUDIOFORMAT="1"/>
+               JUCE_WEB_BROWSER="0" JUCE_USE_MP3AUDIOFORMAT="1"/>
   <EXPORTFORMATS>
     <LINUX_MAKE targetFolder="Builds/sosci/LinuxMakefile" smallIcon="KigaoN"
                 bigIcon="KigaoN">

--- a/sosci.jucer
+++ b/sosci.jucer
@@ -3,7 +3,7 @@
 <JUCERPROJECT id="HH2E72" name="sosci" projectType="audioplug" useAppConfig="0"
               addUsingNamespaceToJuceHeader="0" jucerFormatVersion="1" pluginManufacturer="jameshball"
               aaxIdentifier="sh.ball.sosci" cppLanguageStandard="20" projectLineFeed="&#10;"
-              headerPath="./include" version="1.1.4.3" companyName="James H Ball"
+              headerPath="./include" version="1.1.5.0" companyName="James H Ball"
               companyWebsite="https://osci-render.com" companyEmail="james@ball.sh"
               defines="NOMINMAX=1&#10;INTERNET_FLAG_NO_AUTO_REDIRECT=0&#10;SOSCI_FEATURES=1&#10;JUCE_USE_CUSTOM_PLUGIN_STANDALONE_APP=1"
               pluginManufacturerCode="Jhba" pluginCode="Sosc" pluginAUMainType="'aufx'">


### PR DESCRIPTION
## All applications
- Fixed the visualiser not appearing, being black, or having glitches on many Intel graphics computers
- Applications are now properly DPI and scale-aware on Windows, meaning there should be fewer issues when moving between windows with different scales set.
- Replaced the slider range button with a more generic settings button that allows you to control all slider settings
- Added new LFO start and end parameters that control the LFO's range, effectively allowing you to automate the min and max values of every slider.
- Added a new parameter to each slider that allows you to control how quickly the slider changes value, called 'Smooth Value Change Speed'
- Improved the sizing and spacing of the recording and visualiser settings
## osci-render only
- Added the current file name to the window title