### PR TITLE
Interaction toggle

### DIFF
--- a/Source/CommonPluginEditor.cpp
+++ b/Source/CommonPluginEditor.cpp
@@ -113,7 +113,7 @@ CommonPluginEditor::~CommonPluginEditor() {
 
 bool CommonPluginEditor::keyPressed(const juce::KeyPress& key) {
     // If we're not accepting special keys, end early
-    if (audioProcessor.getGlobalBoolValue("acceptsAllKeys", juce::JUCEApplicationBase::isStandaloneApp()) == false) return false;
+    if (!audioProcessor.getAcceptsKeys()) return false;
 
     if (key.getModifiers().isCommandDown() && key.getModifiers().isShiftDown() && key.getKeyCode() == 'S') {
         saveProjectAs();

--- a/Source/CommonPluginEditor.cpp
+++ b/Source/CommonPluginEditor.cpp
@@ -113,7 +113,7 @@ CommonPluginEditor::~CommonPluginEditor() {
 
 bool CommonPluginEditor::keyPressed(const juce::KeyPress& key) {
     // If we're not accepting special keys, end early
-    if (audioProcessor.acceptsAllKeys == false) return false;
+    if (audioProcessor.getGlobalBoolValue("acceptsAllKeys", juce::JUCEApplicationBase::isStandaloneApp()) == false) return false;
 
     if (key.getModifiers().isCommandDown() && key.getModifiers().isShiftDown() && key.getKeyCode() == 'S') {
         saveProjectAs();

--- a/Source/CommonPluginEditor.cpp
+++ b/Source/CommonPluginEditor.cpp
@@ -112,6 +112,9 @@ CommonPluginEditor::~CommonPluginEditor() {
 }
 
 bool CommonPluginEditor::keyPressed(const juce::KeyPress& key) {
+    // If we're not accepting special keys, end early
+    if (audioProcessor.acceptsAllKeys == false) return false;
+
     if (key.getModifiers().isCommandDown() && key.getModifiers().isShiftDown() && key.getKeyCode() == 'S') {
         saveProjectAs();
     } else if (key.getModifiers().isCommandDown() && key.getKeyCode() == 'S') {

--- a/Source/CommonPluginProcessor.cpp
+++ b/Source/CommonPluginProcessor.cpp
@@ -16,7 +16,6 @@ CommonAudioProcessor::CommonAudioProcessor(const BusesProperties& busesPropertie
      : AudioProcessor(busesProperties)
 #endif
 {
-    acceptsAllKeys = juce::JUCEApplicationBase::isStandaloneApp();
 
     if (!applicationFolder.exists()) {
         applicationFolder.createDirectory();

--- a/Source/CommonPluginProcessor.cpp
+++ b/Source/CommonPluginProcessor.cpp
@@ -16,6 +16,8 @@ CommonAudioProcessor::CommonAudioProcessor(const BusesProperties& busesPropertie
      : AudioProcessor(busesProperties)
 #endif
 {
+    acceptsAllKeys = juce::JUCEApplicationBase::isStandaloneApp();
+
     if (!applicationFolder.exists()) {
         applicationFolder.createDirectory();
     }

--- a/Source/CommonPluginProcessor.h
+++ b/Source/CommonPluginProcessor.h
@@ -153,8 +153,11 @@ public:
 #else
         "ffmpeg";
 #endif
-    void setAcceptKeys(bool shouldAcceptKeys) {
+    void setAcceptsKeys(bool shouldAcceptKeys) {
         setGlobalValue("acceptsAllKeys", shouldAcceptKeys);
+    }
+    bool getAcceptsKeys() {
+        return getGlobalBoolValue("acceptsAllKeys", juce::JUCEApplicationBase::isStandaloneApp());
     }
 
 protected:

--- a/Source/CommonPluginProcessor.h
+++ b/Source/CommonPluginProcessor.h
@@ -153,9 +153,8 @@ public:
 #else
         "ffmpeg";
 #endif
-    bool acceptsAllKeys;
     void setAcceptKeys(bool shouldAcceptKeys) {
-        acceptsAllKeys = shouldAcceptKeys;
+        setGlobalValue("acceptsAllKeys", shouldAcceptKeys);
     }
 
 protected:

--- a/Source/CommonPluginProcessor.h
+++ b/Source/CommonPluginProcessor.h
@@ -153,6 +153,10 @@ public:
 #else
         "ffmpeg";
 #endif
+    bool acceptsAllKeys;
+    void setAcceptKeys(bool shouldAcceptKeys) {
+        acceptsAllKeys = shouldAcceptKeys;
+    }
 
 protected:
     

--- a/Source/components/OsciMainMenuBarModel.cpp
+++ b/Source/components/OsciMainMenuBarModel.cpp
@@ -61,8 +61,8 @@ void OsciMainMenuBarModel::resetMenuItems() {
     addMenuItem(1, "Randomize Blender Port", [this] {
         audioProcessor.setObjectServerPort(juce::Random::getSystemRandom().nextInt(juce::Range<int>(51600, 51700)));
         });
-    addMenuItem(1, audioProcessor.acceptsAllKeys ? "Disable Special Keys" : "Enable Special Keys", [this] {
-        audioProcessor.setAcceptKeys(!audioProcessor.acceptsAllKeys);
+    addMenuItem(1, audioProcessor.getGlobalBoolValue("acceptsAllKeys", juce::JUCEApplicationBase::isStandaloneApp()) ? "Disable Special Keys" : "Enable Special Keys", [this] {
+        audioProcessor.setAcceptKeys(!audioProcessor.getGlobalBoolValue("acceptsAllKeys", juce::JUCEApplicationBase::isStandaloneApp()));
         resetMenuItems();
         });
 

--- a/Source/components/OsciMainMenuBarModel.cpp
+++ b/Source/components/OsciMainMenuBarModel.cpp
@@ -61,8 +61,8 @@ void OsciMainMenuBarModel::resetMenuItems() {
     addMenuItem(1, "Randomize Blender Port", [this] {
         audioProcessor.setObjectServerPort(juce::Random::getSystemRandom().nextInt(juce::Range<int>(51600, 51700)));
         });
-    addMenuItem(1, audioProcessor.getGlobalBoolValue("acceptsAllKeys", juce::JUCEApplicationBase::isStandaloneApp()) ? "Disable Special Keys" : "Enable Special Keys", [this] {
-        audioProcessor.setAcceptKeys(!audioProcessor.getGlobalBoolValue("acceptsAllKeys", juce::JUCEApplicationBase::isStandaloneApp()));
+    addMenuItem(1, audioProcessor.getAcceptsKeys() ? "Disable Special Keys" : "Enable Special Keys", [this] {
+        audioProcessor.setAcceptsKeys(!audioProcessor.getAcceptsKeys());
         resetMenuItems();
         });
 

--- a/Source/components/OsciMainMenuBarModel.cpp
+++ b/Source/components/OsciMainMenuBarModel.cpp
@@ -60,7 +60,11 @@ void OsciMainMenuBarModel::resetMenuItems() {
     });
     addMenuItem(1, "Randomize Blender Port", [this] {
         audioProcessor.setObjectServerPort(juce::Random::getSystemRandom().nextInt(juce::Range<int>(51600, 51700)));
-    });
+        });
+    addMenuItem(1, audioProcessor.acceptsAllKeys ? "Disable Special Keys" : "Enable Special Keys", [this] {
+        audioProcessor.setAcceptKeys(!audioProcessor.acceptsAllKeys);
+        resetMenuItems();
+        });
 
 #if !OSCI_PREMIUM
     addMenuItem(1, "Purchase osci-render premium!", [this] {

--- a/Source/components/SosciMainMenuBarModel.cpp
+++ b/Source/components/SosciMainMenuBarModel.cpp
@@ -96,8 +96,8 @@ void SosciMainMenuBarModel::resetMenuItems() {
 
         juce::DialogWindow* dw = options.launchAsync();
     });
-    addMenuItem(1, processor.acceptsAllKeys ? "Disable Special Keys" : "Enable Special Keys", [this] {
-        processor.setAcceptKeys(!processor.acceptsAllKeys);
+    addMenuItem(1, processor.getGlobalBoolValue("acceptsAllKeys", juce::JUCEApplicationBase::isStandaloneApp()) ? "Disable Special Keys" : "Enable Special Keys", [this] {
+        processor.setAcceptKeys(!processor.getGlobalBoolValue("acceptsAllKeys", juce::JUCEApplicationBase::isStandaloneApp()));
         resetMenuItems();
         });
 

--- a/Source/components/SosciMainMenuBarModel.cpp
+++ b/Source/components/SosciMainMenuBarModel.cpp
@@ -4,6 +4,10 @@
 #include "../SosciPluginProcessor.h"
 
 SosciMainMenuBarModel::SosciMainMenuBarModel(SosciPluginEditor& e, SosciAudioProcessor& p) : editor(e), processor(p) {
+    resetMenuItems();
+}
+
+void SosciMainMenuBarModel::resetMenuItems() {
     addTopLevelMenu("File");
     addTopLevelMenu("About");
     addTopLevelMenu("Video");
@@ -92,6 +96,10 @@ SosciMainMenuBarModel::SosciMainMenuBarModel(SosciPluginEditor& e, SosciAudioPro
 
         juce::DialogWindow* dw = options.launchAsync();
     });
+    addMenuItem(1, processor.acceptsAllKeys ? "Disable Special Keys" : "Enable Special Keys", [this] {
+        processor.setAcceptKeys(!processor.acceptsAllKeys);
+        resetMenuItems();
+        });
 
     addMenuItem(2, "Settings...", [this] {
         editor.openRecordingSettings();

--- a/Source/components/SosciMainMenuBarModel.cpp
+++ b/Source/components/SosciMainMenuBarModel.cpp
@@ -96,8 +96,8 @@ void SosciMainMenuBarModel::resetMenuItems() {
 
         juce::DialogWindow* dw = options.launchAsync();
     });
-    addMenuItem(1, processor.getGlobalBoolValue("acceptsAllKeys", juce::JUCEApplicationBase::isStandaloneApp()) ? "Disable Special Keys" : "Enable Special Keys", [this] {
-        processor.setAcceptKeys(!processor.getGlobalBoolValue("acceptsAllKeys", juce::JUCEApplicationBase::isStandaloneApp()));
+    addMenuItem(1, processor.getAcceptsKeys() ? "Disable Special Keys" : "Enable Special Keys", [this] {
+        processor.setAcceptsKeys(!processor.getAcceptsKeys());
         resetMenuItems();
         });
 

--- a/Source/components/SosciMainMenuBarModel.h
+++ b/Source/components/SosciMainMenuBarModel.h
@@ -9,6 +9,7 @@ class SosciAudioProcessor;
 class SosciMainMenuBarModel : public MainMenuBarModel {
 public:
     SosciMainMenuBarModel(SosciPluginEditor& editor, SosciAudioProcessor& processor);
+    void resetMenuItems();
 
     SosciPluginEditor& editor;
     SosciAudioProcessor& processor;

--- a/Source/visualiser/VisualiserComponent.cpp
+++ b/Source/visualiser/VisualiserComponent.cpp
@@ -255,7 +255,7 @@ void VisualiserComponent::mouseDown(const juce::MouseEvent &event) {
 
 bool VisualiserComponent::keyPressed(const juce::KeyPress &key) {
     // If we're not accepting special keys, end early
-    if (audioProcessor.getGlobalBoolValue("acceptsAllKeys", juce::JUCEApplicationBase::isStandaloneApp()) == false) return false;
+    if (!audioProcessor.getAcceptsKeys()) return false;
 
     if (key.isKeyCode(juce::KeyPress::escapeKey)) {
         if (fullScreenCallback) {

--- a/Source/visualiser/VisualiserComponent.cpp
+++ b/Source/visualiser/VisualiserComponent.cpp
@@ -255,7 +255,7 @@ void VisualiserComponent::mouseDown(const juce::MouseEvent &event) {
 
 bool VisualiserComponent::keyPressed(const juce::KeyPress &key) {
     // If we're not accepting special keys, end early
-    if (audioProcessor.acceptsAllKeys == false) return false;
+    if (audioProcessor.getGlobalBoolValue("acceptsAllKeys", juce::JUCEApplicationBase::isStandaloneApp()) == false) return false;
 
     if (key.isKeyCode(juce::KeyPress::escapeKey)) {
         if (fullScreenCallback) {

--- a/Source/visualiser/VisualiserComponent.cpp
+++ b/Source/visualiser/VisualiserComponent.cpp
@@ -254,6 +254,9 @@ void VisualiserComponent::mouseDown(const juce::MouseEvent &event) {
 }
 
 bool VisualiserComponent::keyPressed(const juce::KeyPress &key) {
+    // If we're not accepting special keys, end early
+    if (audioProcessor.acceptsAllKeys == false) return false;
+
     if (key.isKeyCode(juce::KeyPress::escapeKey)) {
         if (fullScreenCallback) {
             fullScreenCallback(FullScreenMode::MAIN_COMPONENT);


### PR DESCRIPTION
This update adds a setting to enable or disable intercepting special keys (such as ctrl-s and the spacebar). This setting is enabled by default on the standalone and disabled by default on plugins, as plugins intercepting these shortcuts can be very annoying when working in a DAW.