### PR TITLE
Hypercube, Mushroom, Spiral example improvements

### DIFF
--- a/Resources/lua/hypercube.lua
+++ b/Resources/lua/hypercube.lua
@@ -46,16 +46,16 @@ local path = {
     10, 11, 12, 9, 1, 2, 3, 4
 }
 
-local NUM_EDGES = #path
+local PATH_LENGTH = #path
 
-local railroad_switch = NUM_EDGES * phase / (2 * math.pi)
+local railroad_switch = PATH_LENGTH * phase / (2 * math.pi)
 local current_vertex = math.floor(railroad_switch) + 1
-local next_vertex = current_vertex % NUM_EDGES + 1
+local next_vertex = current_vertex % PATH_LENGTH + 1
 local edge_phase = railroad_switch % 1
 
 local time = step/sample_rate * ANIMATION_SPEED
 
-if current_vertex <= NUM_EDGES then
+if current_vertex <= PATH_LENGTH then
     local v1 = vertices[path[current_vertex]]
     local v2 = vertices[path[next_vertex]]
     

--- a/Resources/lua/hypercube.lua
+++ b/Resources/lua/hypercube.lua
@@ -1,5 +1,6 @@
 local SCALE = 1.0
 local ANIMATION_SPEED = 1.0
+local FOV_4D = math.rad(80)
 
 local function rotate4D_XY(x, y, z, w, angle)
     return x * math.cos(angle) - y * math.sin(angle),
@@ -23,8 +24,9 @@ local function rotate4D_XW(x, y, z, w, angle)
 end
 
 local function project4Dto3D(x, y, z, w)
-    local w_factor = 1 / (3 - w)
-    return x * w_factor, y * w_factor, z * w_factor
+    local camera_w = -1 / math.sin(0.5 * FOV_4D)
+    local scale = 1 / (w - camera_w) / math.tan(0.5 * FOV_4D)
+    return x * scale, y * scale, z * scale
 end
 
 local vertices = {
@@ -36,36 +38,37 @@ local vertices = {
     {-1, -1, 1, 1}, {1, -1, 1, 1}, {1, 1, 1, 1}, {-1, 1, 1, 1}
 }
 
-local edges = {
-    -- Inner cube edges
-    {1, 2}, {2, 3}, {3, 4}, {4, 1},
-    {5, 6}, {6, 7}, {7, 8}, {8, 5},
-    {1, 5}, {2, 6}, {3, 7}, {4, 8},
-    -- Outer cube edges
-    {9, 10}, {10, 11}, {11, 12}, {12, 9},
-    {13, 14}, {14, 15}, {15, 16}, {16, 13},
-    {9, 13}, {10, 14}, {11, 15}, {12, 16},
-    -- Connections between cubes
-    {1, 9}, {2, 10}, {3, 11}, {4, 12},
-    {5, 13}, {6, 14}, {7, 15}, {8, 16}
+-- Eulerian cycle through vertices
+local path = {
+    1, 5, 8, 4, 12, 16, 15, 11,
+    3, 7, 6, 14, 15, 7, 8, 16,
+    13, 5, 6, 2, 10, 9, 13, 14,
+    10, 11, 12, 9, 1, 2, 3, 4
 }
 
-local NUM_EDGES = #edges
+local NUM_EDGES = #path
 
 local railroad_switch = NUM_EDGES * phase / (2 * math.pi)
-local current_edge = math.floor(railroad_switch) + 1
+local current_vertex = math.floor(railroad_switch) + 1
+local next_vertex = current_vertex % NUM_EDGES + 1
 local edge_phase = railroad_switch % 1
 
 local time = step/sample_rate * ANIMATION_SPEED
 
-if current_edge <= NUM_EDGES then
-    local v1 = vertices[edges[current_edge][1]]
-    local v2 = vertices[edges[current_edge][2]]
+if current_vertex <= NUM_EDGES then
+    local v1 = vertices[path[current_vertex]]
+    local v2 = vertices[path[next_vertex]]
     
     local x = v1[1] + (v2[1] - v1[1]) * edge_phase
     local y = v1[2] + (v2[2] - v1[2]) * edge_phase
     local z = v1[3] + (v2[3] - v1[3]) * edge_phase
     local w = v1[4] + (v2[4] - v1[4]) * edge_phase
+
+    -- Normalize
+    x = x * 0.5
+    y = y * 0.5
+    z = z * 0.5
+    w = w * 0.5
     
     local fold_angle = math.sin(time) * math.pi / 2
     

--- a/Resources/lua/mushroom.lua
+++ b/Resources/lua/mushroom.lua
@@ -1,9 +1,9 @@
-local X_SIZE = 0.35
+local LOOPS = 30
+local CAP_WIDTH = 0.35
 local STEM_WIDTH = 0.05
 local Y_SIZE = 0.02
 local HEIGHT = 2.0
 local OFFSET_Y = -1.0
-local LOOPS = 50
 local SHROOMS = 3 -- can be 1-4
 
 local MOVE_AMOUNT = 0.4
@@ -13,27 +13,34 @@ local SPREAD = 0.2
 local railroad_switch = SHROOMS * phase / (2 * math.pi)
 local drawing_phase = (phase * SHROOMS) % (2 * math.pi)
 
-local x = X_SIZE * math.cos(LOOPS * drawing_phase)
-local y = Y_SIZE * math.sin(LOOPS * drawing_phase)
+local x = CAP_WIDTH * math.cos(LOOPS * drawing_phase)
+local z = CAP_WIDTH * math.sin(LOOPS * drawing_phase)
 
 local sawtooth = (drawing_phase % (2 * math.pi)) / (2 * math.pi)
-y = y + (HEIGHT * sawtooth) + OFFSET_Y
+local y = HEIGHT * sawtooth + OFFSET_Y
 
 local sine_mod = math.sin(2 * math.pi * sawtooth)
 
 if sawtooth < 0.75 then
-    sine_mod = 1
-    x = x * (STEM_WIDTH / X_SIZE)
+    sine_mod = STEM_WIDTH / CAP_WIDTH
 end
 
 x = x * sine_mod
+z = z * sine_mod
 
 local base_time = step/sample_rate * MOVE_FREQ
 local current_mushroom = math.floor(railroad_switch)
 local phase_offset = current_mushroom / SHROOMS
 
-local wiggle = math.sin(2 * math.pi * (sawtooth + base_time + phase_offset)) * sawtooth
-local outer_drift = SPREAD * sawtooth * wiggle
-x = x + (MOVE_AMOUNT * wiggle + outer_drift)
+local wiggle_x = math.cos(2 * math.pi * (sawtooth + base_time + phase_offset)) * sawtooth
+local wiggle_z = math.sin(2 * math.pi * (sawtooth + base_time + phase_offset)) * sawtooth
+local outer_drift_x = SPREAD * sawtooth * wiggle_x
+local outer_drift_z = SPREAD * sawtooth * wiggle_z
+x = x + (MOVE_AMOUNT * wiggle_x + outer_drift_x)
+z = z + (MOVE_AMOUNT * wiggle_z + outer_drift_z)
 
-return {x, y}
+-- normalize for default HEIGHT and OFFSET_Y
+local max_xz = math.abs(MOVE_AMOUNT) + math.abs(SPREAD)
+local scale = 1 / math.sqrt(1 + max_xz * max_xz)
+
+return {x * scale, y * scale, z * scale}

--- a/Resources/lua/mushroom.lua
+++ b/Resources/lua/mushroom.lua
@@ -1,7 +1,6 @@
 local LOOPS = 30
 local CAP_WIDTH = 0.35
 local STEM_WIDTH = 0.05
-local Y_SIZE = 0.02
 local HEIGHT = 2.0
 local OFFSET_Y = -1.0
 local SHROOMS = 3 -- can be 1-4

--- a/Resources/lua/spiral.lua
+++ b/Resources/lua/spiral.lua
@@ -34,7 +34,7 @@ dir = dir or 1
 t = t or 0
 -- This is the correct increment for t to use such
 -- that we hear the right frequency.
-increment = 2 * math.pi * frequency / sample_rate
+increment = 4 * math.pi * frequency / sample_rate
 
 -- If we get to the end of the spiral, flip the
 -- direction to go back.


### PR DESCRIPTION
### Hypercube
* Use Eulerian cycle traversal to remove all instant jumps
* Normalize vertices and perspective projection

### Mushroom
* Make 3D
* Normalize
  * Normalized for default height and y offset values - so if users change them, the visuals will properly reflect the changes
* Reduce number of default loops so they are better represented at default frequency and typical sample rate

### Spiral
* Correct frequency