### PR TITLE
Fix memory leak in VListBox.cpp

### DIFF
--- a/Source/components/VListBox.cpp
+++ b/Source/components/VListBox.cpp
@@ -166,7 +166,7 @@ public:
         setWantsKeyboardFocus (false);
 
     auto content = new juce::Component();
-    setViewedComponent(content, false);
+    setViewedComponent(content, true);
         content->setWantsKeyboardFocus (false);
 
     // Enable scroll fades for list views by default
@@ -1076,3 +1076,4 @@ juce::MouseCursor VListBoxModel::getMouseCursorForRow (int)
 {
     return juce::MouseCursor::NormalCursor;
 }
+


### PR DESCRIPTION
On line 169, setting the second parameter to `false` makes the `juce::Component content` never get deleted, causing a memory leak. This PR switches it to `true`, which fixes the issue by deleting the `juce::Component` once it's no longer needed.