### PR TITLE
Fix stale envelope state when changing tabs

### DIFF
--- a/Source/components/modulation/EnvelopeComponent.cpp
+++ b/Source/components/modulation/EnvelopeComponent.cpp
@@ -203,8 +203,7 @@ void EnvelopeComponent::initEnvelopeData(int envIndex) {
     envData[envIndex].nodes = buildDahdsrNodes(audioProcessor.getCurrentDahdsrParams(envIndex));
 }
 
-void EnvelopeComponent::onActiveSourceChanged(int index) {
-    envData[activeSourceIndex].nodes = graph.getNodes();
+void EnvelopeComponent::onActiveSourceChanged(int) {
     syncGraphToActiveEnv();
     syncKnobsToActiveEnv();
     graph.resetFlowTrail();


### PR DESCRIPTION
## Summary

- stop writing the outgoing graph nodes back into the newly selected envelope slot
- resynchronise the graph and controls from the active envelope on every tab change

## Root cause

The active source index had already changed when the callback ran, so the outgoing graph state was copied into the incoming envelope and made that tab appear stale.

## Validation

- full Debug unit suite
- Debug arm64 standalone build
- git diff --check