### PR TITLE
Add standalone internal sample-rate ratios

### DIFF
--- a/Source/CommonPluginProcessor.cpp
+++ b/Source/CommonPluginProcessor.cpp
@@ -12,6 +12,8 @@
 #include "audio/OutputClip.h"
 #include "components/OverlayDialogHelpers.h"
 
+#include <cmath>
+
 namespace
 {
     osci::LicenseManager::Config makeLicenseManagerConfig() {
@@ -81,6 +83,15 @@ CommonAudioProcessor::CommonAudioProcessor(const BusesProperties& busesPropertie
     if (licenseStatus == osci::LicenseManager::Status::PremiumCachedToken
         || licenseStatus == osci::LicenseManager::Status::ExpiredOffline) {
         licenseManager.scheduleBackgroundRefresh();
+    }
+
+    // Restore internal sample-rate ratio (1.0 = follow device).
+    {
+#if OSCI_PREMIUM
+        internalSampleRate.restoreSavedRatio(globalSettings.getDouble(InternalSampleRateController::settingKey, 1.0));
+#else
+        internalSampleRate.restoreSavedRatio(1.0);
+#endif
     }
 
     // Restore recently-opened project files (shared across instances).
@@ -371,13 +382,66 @@ void CommonAudioProcessor::prepareToPlay(double sampleRate, int samplesPerBlock)
         + " samplesPerBlock=" + juce::String(samplesPerBlock)
         + " effects=" + juce::String(effects.size()));
 
-	currentSampleRate = sampleRate;
+    const int numChannels = juce::jmax(getTotalNumInputChannels(), getTotalNumOutputChannels(), 1);
+    const auto prepared = internalSampleRate.prepare(sampleRate, samplesPerBlock, numChannels, supportsInternalSampleRateOverride());
+    const double internalRate = prepared.sampleRate;
+    const int internalBlock = prepared.blockSize;
+    currentSampleRate.store(internalRate);
+    setLatencySamples(prepared.latencySamples);
 
     for (auto& effect : effects) {
-        effect->prepareToPlay(currentSampleRate, samplesPerBlock);
+        effect->prepareToPlay(internalRate, internalBlock);
     }
 
-    threadManager.prepare(sampleRate, samplesPerBlock);
+    threadManager.prepare(internalRate, internalBlock);
+    prepareToPlayInternal(internalRate, internalBlock);
+}
+
+void CommonAudioProcessor::processBlock(juce::AudioBuffer<float>& buffer, juce::MidiBuffer& midi) {
+    const int deviceNumSamples = buffer.getNumSamples();
+    if (deviceNumSamples <= 0) {
+        return;
+    }
+
+    if (isSuspended()) {
+        buffer.clear();
+        midi.clear();
+        return;
+    }
+
+    internalSampleRate.process(buffer, midi, [this](auto& b, auto& m) { processBlockInternal(b, m); });
+}
+
+bool CommonAudioProcessor::canSetInternalSampleRateRatio(double ratio) const {
+#if OSCI_PREMIUM
+    return supportsInternalSampleRateOverride() && internalSampleRate.canSetRatio(ratio);
+#else
+    return std::abs(ratio - 1.0) < 0.000001;
+#endif
+}
+
+void CommonAudioProcessor::setInternalSampleRateRatio(double ratio) {
+#if !OSCI_PREMIUM
+    juce::ignoreUnused(ratio);
+    return;
+#else
+    if (!supportsInternalSampleRateOverride()) {
+        return;
+    }
+
+    if (!internalSampleRate.setRatio(ratio)) {
+        return;
+    }
+
+    globalSettings.set(InternalSampleRateController::settingKey, internalSampleRate.getRatio());
+    globalSettings.save();
+
+    if (internalSampleRate.hasPreparedDevice()) {
+        suspendProcessing(true);
+        prepareToPlay(internalSampleRate.getLastDeviceSampleRate(), internalSampleRate.getLastDeviceBlockSize());
+        suspendProcessing(false);
+    }
+#endif
 }
 
 void CommonAudioProcessor::releaseResources() {
@@ -428,11 +492,16 @@ osci::IntParameter* CommonAudioProcessor::getIntParameter(juce::String id) {
 
 //==============================================================================
 bool CommonAudioProcessor::hasEditor() const {
-    return true; // (change this to false if you choose to not supply an editor)
+    return true;
 }
 
 double CommonAudioProcessor::getSampleRate() {
-    return currentSampleRate;
+    return getEffectiveSampleRate();
+}
+
+double CommonAudioProcessor::getEffectiveSampleRate() {
+    const double sampleRate = currentSampleRate.load();
+    return sampleRate > 0.0 ? sampleRate : 192000.0;
 }
 
 void CommonAudioProcessor::loadAudioFile(const juce::File& file) {

--- a/Source/CommonPluginProcessor.h
+++ b/Source/CommonPluginProcessor.h
@@ -13,6 +13,7 @@
 #include <any>
 #include <osci_file_import/osci_file_import.h>
 
+#include "audio/platform/InternalSampleRateController.h"
 #include "visualiser/VisualiserSettings.h"
 #include "visualiser/RecordingSettings.h"
 
@@ -36,15 +37,19 @@ public:
     juce::UndoManager& getUndoManager() { return undoManager; }
     juce::String getProductSlug() const;
 
-    void prepareToPlay (double sampleRate, int samplesPerBlock) override;
+    void prepareToPlay (double sampleRate, int samplesPerBlock) override final;
     void releaseResources() override;
 
    #ifndef JucePlugin_PreferredChannelConfigurations
     bool isBusesLayoutSupported (const BusesLayout& layouts) const override;
    #endif
 
-    virtual void processBlock(juce::AudioBuffer<float>&, juce::MidiBuffer&) = 0;
-    virtual juce::AudioProcessorEditor* createEditor() = 0;
+    void processBlock(juce::AudioBuffer<float>&, juce::MidiBuffer&) override final;
+    virtual void processBlockInternal(juce::AudioBuffer<float>&, juce::MidiBuffer&) = 0;
+    virtual void prepareToPlayInternal(double effectiveSampleRate, int internalSamplesPerBlock) {}
+    virtual bool supportsInternalSampleRateOverride() const { return false; }
+
+    juce::AudioProcessorEditor* createEditor() override = 0;
 
     bool hasEditor() const override;
 
@@ -60,6 +65,10 @@ public:
     const juce::String getProgramName(int index) override;
     void changeProgramName(int index, const juce::String& newName) override;
     double getSampleRate();
+    double getEffectiveSampleRate();
+    double getInternalSampleRateRatio() const { return internalSampleRate.getRatio(); }
+    bool canSetInternalSampleRateRatio(double ratio) const;
+    void setInternalSampleRateRatio(double ratio);
     void loadAudioFile(const juce::File& file);
     void loadAudioFile(std::unique_ptr<juce::InputStream> stream);
     void stopAudioFile();
@@ -259,6 +268,8 @@ protected:
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (CommonAudioProcessor)
 
 private:
+    InternalSampleRateController internalSampleRate;
+
     void startHeartbeat();
     void stopHeartbeat();
     void timerCallback() override;

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -441,9 +441,7 @@ void OscirenderAudioProcessor::setAudioThreadCallback(std::function<void(const j
     audioThreadCallback = callback;
 }
 
-void OscirenderAudioProcessor::prepareToPlay(double sampleRate, int samplesPerBlock) {
-    CommonAudioProcessor::prepareToPlay(sampleRate, samplesPerBlock);
-
+void OscirenderAudioProcessor::prepareToPlayInternal(double sampleRate, int samplesPerBlock) {
     defaultEnvelopeState.smoothedLevel = 0.0f;
     synth.handleMidiEvent(juce::MidiMessage::allSoundOff(1));
     synth.setCurrentPlaybackSampleRate(sampleRate);
@@ -906,7 +904,7 @@ void OscirenderAudioProcessor::applyToggleableEffectsToBuffer(
     }
 }
 
-void OscirenderAudioProcessor::processBlock(juce::AudioBuffer<float>& buffer, juce::MidiBuffer& midiMessages) {
+void OscirenderAudioProcessor::processBlockInternal(juce::AudioBuffer<float>& buffer, juce::MidiBuffer& midiMessages) {
     juce::ScopedNoDenormals noDenormals;
     AudioThreadGuard::ScopedAudioThread audioThreadGuard;
 
@@ -918,7 +916,7 @@ void OscirenderAudioProcessor::processBlock(juce::AudioBuffer<float>& buffer, ju
 
     int totalNumInputChannels = getTotalNumInputChannels();
     int totalNumOutputChannels = getTotalNumOutputChannels();
-    double sampleRate = getSampleRate();
+    double sampleRate = getEffectiveSampleRate();
     int numSamples = buffer.getNumSamples();
 
     osci::DawPosition::Options dawPositionOptions;

--- a/Source/PluginProcessor.h
+++ b/Source/PluginProcessor.h
@@ -102,8 +102,11 @@ public:
     // EffectComponents register/unregister via wireModulation / destructor.
     ModulationUpdateBroadcaster modulationUpdateBroadcaster;
 
-    void prepareToPlay(double sampleRate, int samplesPerBlock) override;
-    void processBlock(juce::AudioBuffer<float>&, juce::MidiBuffer&) override;
+    void prepareToPlayInternal(double effectiveSampleRate, int internalSamplesPerBlock) override;
+    void processBlockInternal(juce::AudioBuffer<float>&, juce::MidiBuffer&) override;
+    bool supportsInternalSampleRateOverride() const override {
+        return OSCI_PREMIUM && wrapperType == juce::AudioProcessor::WrapperType::wrapperType_Standalone;
+    }
 
     juce::AudioProcessorEditor* createEditor() override;
 

--- a/Source/SosciPluginProcessor.cpp
+++ b/Source/SosciPluginProcessor.cpp
@@ -14,7 +14,7 @@ SosciAudioProcessor::SosciAudioProcessor() : CommonAudioProcessor(BusesPropertie
 
 SosciAudioProcessor::~SosciAudioProcessor() {}
 
-void SosciAudioProcessor::processBlock(juce::AudioBuffer<float>& buffer, juce::MidiBuffer& midiMessages) {
+void SosciAudioProcessor::processBlockInternal(juce::AudioBuffer<float>& buffer, juce::MidiBuffer& midiMessages) {
     juce::ScopedNoDenormals noDenormals;
     AudioThreadGuard::ScopedAudioThread audioThreadGuard;
 

--- a/Source/SosciPluginProcessor.h
+++ b/Source/SosciPluginProcessor.h
@@ -21,7 +21,7 @@ public:
     SosciAudioProcessor();
     ~SosciAudioProcessor() override;
 
-    void processBlock (juce::AudioBuffer<float>&, juce::MidiBuffer&) override;
+    void processBlockInternal (juce::AudioBuffer<float>&, juce::MidiBuffer&) override;
 
     void getStateInformation(juce::MemoryBlock& destData) override;
     void setStateInformation(const void* data, int sizeInBytes) override;

--- a/Source/audio/platform/InternalSampleRateController.h
+++ b/Source/audio/platform/InternalSampleRateController.h
@@ -1,0 +1,88 @@
+#pragma once
+
+#include <JuceHeader.h>
+#include <osci_render_core/osci_render_core.h>
+
+#include <cmath>
+
+class InternalSampleRateController {
+public:
+    struct PreparedSpec {
+        double sampleRate = 0.0;
+        int blockSize = 0;
+        int latencySamples = 0;
+    };
+
+    static constexpr const char* settingKey = "internalSampleRateRatio";
+
+    void restoreSavedRatio(double savedRatio) noexcept {
+        ratio.store(osci::IntegerRatioSampleRateAdapter::isRatioSupported(savedRatio)
+            ? osci::IntegerRatioSampleRateAdapter::normaliseRatio(savedRatio)
+            : 1.0);
+    }
+
+    [[nodiscard]] double getRatio() const noexcept { return ratio.load(); }
+    [[nodiscard]] double getLastDeviceSampleRate() const noexcept { return lastDeviceSampleRate; }
+    [[nodiscard]] int getLastDeviceBlockSize() const noexcept { return lastDeviceBlockSize; }
+    [[nodiscard]] bool hasPreparedDevice() const noexcept { return lastDeviceSampleRate > 0.0 && lastDeviceBlockSize > 0; }
+
+    [[nodiscard]] bool canSetRatio(double newRatio) const noexcept {
+        if (!osci::IntegerRatioSampleRateAdapter::isRatioSupported(newRatio)) {
+            return false;
+        }
+
+        newRatio = osci::IntegerRatioSampleRateAdapter::normaliseRatio(newRatio);
+        return osci::IntegerRatioSampleRateAdapter::isRatioAllowed(lastDeviceSampleRate, newRatio);
+    }
+
+    PreparedSpec prepare(double deviceSampleRate, int maxDeviceBlockSize, int numChannels, bool enabled) {
+        lastDeviceSampleRate = deviceSampleRate;
+        lastDeviceBlockSize = maxDeviceBlockSize;
+
+        const auto requestedRatio = enabled ? ratio.load() : 1.0;
+        const auto effectiveRatio = enabled && osci::IntegerRatioSampleRateAdapter::isRatioAllowed(deviceSampleRate, requestedRatio)
+            ? osci::IntegerRatioSampleRateAdapter::normaliseRatio(requestedRatio)
+            : 1.0;
+
+        ratio.store(effectiveRatio);
+        adapter.prepare({ deviceSampleRate, effectiveRatio, maxDeviceBlockSize, numChannels });
+
+        return {
+            adapter.getProcessingSampleRate(),
+            adapter.getMaxProcessingBlockSize(),
+            adapter.getLatencySamples()
+        };
+    }
+
+    bool setRatio(double newRatio) noexcept {
+        if (!canSetRatio(newRatio)) {
+            return false;
+        }
+
+        newRatio = osci::IntegerRatioSampleRateAdapter::normaliseRatio(newRatio);
+        if (std::abs(newRatio - ratio.load()) < 0.000001) {
+            return false;
+        }
+
+        ratio.store(newRatio);
+        return true;
+    }
+
+    template <typename ProcessInternal>
+    osci::IntegerRatioSampleRateAdapter::ProcessResult process(juce::AudioBuffer<float>& buffer, juce::MidiBuffer& midi, ProcessInternal&& processInternal) noexcept {
+        if (adapter.isActive()) {
+            return adapter.process(buffer, midi, std::forward<ProcessInternal>(processInternal));
+        }
+
+        osci::IntegerRatioSampleRateAdapter::ProcessResult result;
+        processInternal(buffer, midi);
+        result.internalSamplesProcessed = buffer.getNumSamples();
+        return result;
+    }
+
+private:
+    std::atomic<double> ratio{1.0};
+    double lastDeviceSampleRate = 0.0;
+    int lastDeviceBlockSize = 0;
+    osci::IntegerRatioSampleRateAdapter adapter;
+};

--- a/Source/audio/synth/ShapeVoice.cpp
+++ b/Source/audio/synth/ShapeVoice.cpp
@@ -16,7 +16,7 @@ void ShapeVoice::initializeEffectsFromGlobal() {
         if (simpleEffect) {
             auto cloned = simpleEffect->cloneWithSharedParameters();
             // Initialize the effect with current sample rate
-            const double sampleRate = audioProcessor.currentSampleRate.load();
+            const double sampleRate = audioProcessor.getEffectiveSampleRate();
             if (sampleRate > 0) {
                 cloned->prepareToPlay(sampleRate, 512);
             }
@@ -29,7 +29,7 @@ void ShapeVoice::setPreviewEffect(std::shared_ptr<osci::SimpleEffect> effect) {
     if (effect) {
         voicePreviewEffect = effect->cloneWithSharedParameters();
         // Initialize the effect with current sample rate
-        const double sampleRate = audioProcessor.currentSampleRate.load();
+        const double sampleRate = audioProcessor.getEffectiveSampleRate();
         if (sampleRate > 0) {
             voicePreviewEffect->prepareToPlay(sampleRate, 512);
         }
@@ -284,7 +284,7 @@ void ShapeVoice::renderNextBlock(juce::AudioSampleBuffer& outputBuffer, int star
     frameSyncBuffer.clear();
 
     const bool midiEnabled = audioProcessor.midiEnabled->getBoolValue();
-    const double sampleRate = audioProcessor.currentSampleRate.load();
+    const double sampleRate = audioProcessor.getEffectiveSampleRate();
     const double dt = 1.0 / sampleRate;
 
     // Snapshot DAW transport once per block (constant within a processBlock call)

--- a/Source/components/menu/InternalSampleRateMenu.cpp
+++ b/Source/components/menu/InternalSampleRateMenu.cpp
@@ -1,0 +1,75 @@
+#include "InternalSampleRateMenu.h"
+
+#include "../../CommonPluginProcessor.h"
+
+#include <cmath>
+
+namespace {
+constexpr double ratioEpsilon = 0.000001;
+
+juce::String getRatioLabel(double ratio) {
+    if (ratio < 1.0) {
+        return "1/" + juce::String(juce::roundToInt(1.0 / ratio)) + " x";
+    }
+
+    return juce::String(juce::roundToInt(ratio)) + " x";
+}
+
+bool getRatioForMenuId(int menuItemId, int baseId, double& selectedRatio) noexcept {
+    const auto& ratios = osci::IntegerRatioSampleRateAdapter::getSupportedRatios();
+    const auto index = menuItemId - baseId;
+
+    if (index < 0 || index >= (int)ratios.size()) {
+        return false;
+    }
+
+    selectedRatio = ratios[(size_t)index];
+    return true;
+}
+}
+
+namespace InternalSampleRateMenu {
+void addSubmenu(juce::PopupMenu& menu, CommonAudioProcessor& processor, int baseId) {
+    juce::PopupMenu sub;
+    const auto currentRatio = processor.getInternalSampleRateRatio();
+    const auto& ratios = osci::IntegerRatioSampleRateAdapter::getSupportedRatios();
+
+    for (size_t i = 0; i < ratios.size(); ++i) {
+        const auto optionRatio = ratios[i];
+        sub.addItem(baseId + (int)i,
+                     getRatioLabel(optionRatio),
+#if OSCI_PREMIUM
+                     processor.canSetInternalSampleRateRatio(optionRatio),
+#else
+                     true,
+#endif
+                     std::abs(optionRatio - currentRatio) < ratioEpsilon);
+    }
+
+    menu.addSubMenu("Internal Sample Rate", sub);
+}
+
+bool handleMenuId(int menuItemId, int baseId, CommonAudioProcessor& processor, std::function<void()> showPremiumSplashScreen) {
+    double ratio = 1.0;
+    if (!getRatioForMenuId(menuItemId, baseId, ratio)) {
+        return false;
+    }
+
+#if !OSCI_PREMIUM
+    if (std::abs(ratio - 1.0) >= ratioEpsilon) {
+        if (showPremiumSplashScreen != nullptr) {
+            showPremiumSplashScreen();
+        }
+
+        return true;
+    }
+#endif
+
+    if (!processor.canSetInternalSampleRateRatio(ratio)) {
+        return false;
+    }
+
+    processor.setInternalSampleRateRatio(ratio);
+    return true;
+}
+}

--- a/Source/components/menu/InternalSampleRateMenu.h
+++ b/Source/components/menu/InternalSampleRateMenu.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <JuceHeader.h>
+
+class CommonAudioProcessor;
+
+namespace InternalSampleRateMenu {
+void addSubmenu(juce::PopupMenu& menu, CommonAudioProcessor& processor, int baseId);
+bool handleMenuId(int menuItemId, int baseId, CommonAudioProcessor& processor, std::function<void()> showPremiumSplashScreen);
+}

--- a/Source/components/menu/OsciMainMenuBarModel.cpp
+++ b/Source/components/menu/OsciMainMenuBarModel.cpp
@@ -2,6 +2,7 @@
 
 #include "../../PluginEditor.h"
 #include "../../PluginProcessor.h"
+#include "InternalSampleRateMenu.h"
 
 OsciMainMenuBarModel::OsciMainMenuBarModel(OscirenderAudioProcessor& p, OscirenderAudioProcessorEditor& e) : audioProcessor(p), editor(e) {
     resetMenuItems();
@@ -13,6 +14,7 @@ void OsciMainMenuBarModel::resetMenuItems() {
     constexpr int RECENT_BASE_ID = 1000;
     constexpr int TEXTURE_INPUT_DISCONNECT_ID = 2000;
     constexpr int TEXTURE_INPUT_SOURCE_BASE_ID = 2100;
+    constexpr int SAMPLE_RATE_BASE_ID = 3000;
     constexpr int fileMenu = 0;
     constexpr int editMenu = 1;
     constexpr int aboutMenu = 2;
@@ -21,11 +23,7 @@ void OsciMainMenuBarModel::resetMenuItems() {
     const int audioMenu = (editor.processor.wrapperType == juce::AudioProcessor::WrapperType::wrapperType_Standalone) ? nextMenu++ : -1;
     const int interfaceMenu = nextMenu;
 
-    customMenuLogic = [this, fileMenu, videoMenu](juce::PopupMenu& menu, int topLevelMenuIndex) {
-        if (topLevelMenuIndex != fileMenu && topLevelMenuIndex != videoMenu) {
-            return;
-        }
-
+    customMenuLogic = [this, fileMenu, videoMenu, audioMenu](juce::PopupMenu& menu, int topLevelMenuIndex) {
         if (topLevelMenuIndex == fileMenu) {
             juce::PopupMenu recentMenu;
             const int added = audioProcessor.createRecentProjectsPopupMenuItems(recentMenu,
@@ -38,6 +36,15 @@ void OsciMainMenuBarModel::resetMenuItems() {
 
             menu.addSubMenu("Open Recent", recentMenu);
             menu.addSeparator();
+            return;
+        }
+
+        if (topLevelMenuIndex == audioMenu) {
+            InternalSampleRateMenu::addSubmenu(menu, audioProcessor, SAMPLE_RATE_BASE_ID);
+            return;
+        }
+
+        if (topLevelMenuIndex != videoMenu) {
             return;
         }
 
@@ -82,7 +89,13 @@ void OsciMainMenuBarModel::resetMenuItems() {
 #endif
     };
 
-    customMenuSelectedLogic = [this, fileMenu, videoMenu](int menuItemID, int topLevelMenuIndex) {
+    customMenuSelectedLogic = [this, fileMenu, videoMenu, audioMenu](int menuItemID, int topLevelMenuIndex) {
+        if (topLevelMenuIndex == audioMenu
+            && InternalSampleRateMenu::handleMenuId(menuItemID, SAMPLE_RATE_BASE_ID, audioProcessor, [this] { editor.showPremiumSplashScreen(); })) {
+            resetMenuItems();
+            return true;
+        }
+
         if (topLevelMenuIndex == fileMenu && menuItemID >= RECENT_BASE_ID) {
             const int index = menuItemID - RECENT_BASE_ID;
             const auto file = audioProcessor.getRecentProjectFile(index);

--- a/osci-render-test.jucer
+++ b/osci-render-test.jucer
@@ -148,6 +148,8 @@
       <FILE id="TstClH" name="TestCleanup.h" compile="0" resource="0" file="tests/TestCleanup.h"/>
       <FILE id="SmpAcc" name="SampleAccuracyTest.cpp" compile="1" resource="0"
             file="tests/SampleAccuracyTest.cpp"/>
+      <FILE id="IrsAdp" name="IntegerRatioSampleRateAdapterTest.cpp" compile="1"
+            resource="0" file="tests/IntegerRatioSampleRateAdapterTest.cpp"/>
     </GROUP>
   </MAINGROUP>
   <MODULES>

--- a/osci-render.jucer
+++ b/osci-render.jucer
@@ -301,6 +301,10 @@
           <FILE id="WId4vx" name="ShapeVoice.h" compile="0" resource="0" file="Source/audio/synth/ShapeVoice.h"/>
           <FILE id="VcBldr" name="VoiceBuilder.h" compile="0" resource="0" file="Source/audio/synth/VoiceBuilder.h"/>
         </GROUP>
+        <GROUP id="{AUD_PLATFORM}" name="platform">
+          <FILE id="IsrCtl" name="InternalSampleRateController.h" compile="0"
+                resource="0" file="Source/audio/platform/InternalSampleRateController.h"/>
+        </GROUP>
         <GROUP id="{AUD_WAV}" name="wav"/>
       </GROUP>
       <GROUP id="{CD81913A-7F0E-5898-DA77-5EBEB369DEB1}" name="components">
@@ -440,6 +444,10 @@
                 file="Source/components/timeline/TimelineLookAndFeel.h"/>
         </GROUP>
         <GROUP id="{CMP_MENU}" name="menu">
+          <FILE id="IsrMnuC" name="InternalSampleRateMenu.cpp" compile="1" resource="0"
+                file="Source/components/menu/InternalSampleRateMenu.cpp"/>
+          <FILE id="IsrMnuH" name="InternalSampleRateMenu.h" compile="0" resource="0"
+                file="Source/components/menu/InternalSampleRateMenu.h"/>
           <FILE id="CfBFAE" name="MainMenuBarModel.cpp" compile="1" resource="0"
                 file="Source/components/menu/MainMenuBarModel.cpp"/>
           <FILE id="ubDcnO" name="MainMenuBarModel.h" compile="0" resource="0"

--- a/tests/IntegerRatioSampleRateAdapterTest.cpp
+++ b/tests/IntegerRatioSampleRateAdapterTest.cpp
@@ -1,0 +1,186 @@
+#include <JuceHeader.h>
+
+namespace
+{
+using Adapter = osci::IntegerRatioSampleRateAdapter;
+
+void fillRamp (juce::AudioBuffer<float>& buffer, int64_t& cursor)
+{
+    for (int sample = 0; sample < buffer.getNumSamples(); ++sample)
+    {
+        const auto value = (float) ((double) cursor++ * 0.0001);
+        for (int channel = 0; channel < buffer.getNumChannels(); ++channel)
+            buffer.setSample (channel, sample, value);
+    }
+}
+
+std::vector<int> makeVariableBlocks (int maxBlock, int count)
+{
+    const int pattern[] { 1, 2, 3, 5, 8, 13, 21, 32, 47, 64, 89, 127, 181, 251, 379, 512 };
+    std::vector<int> blocks;
+    blocks.reserve ((size_t) count);
+
+    for (int i = 0; i < count; ++i)
+        blocks.push_back (juce::jlimit (1, maxBlock, pattern[(size_t) i % std::size (pattern)]));
+
+    return blocks;
+}
+} // namespace
+
+class IntegerRatioSampleRateAdapterTest : public juce::UnitTest
+{
+public:
+    IntegerRatioSampleRateAdapterTest() : juce::UnitTest ("Integer Ratio Sample Rate Adapter", "DSP") {}
+
+    void runTest() override
+    {
+        testRatioValidation();
+        testBypass();
+        testOversamplingRatios();
+        testMidiMapping();
+        testOversizeBlockFailsSafely();
+    }
+
+private:
+    void testRatioValidation()
+    {
+        beginTest ("Ratio validation");
+
+        expectEquals ((int) Adapter::getSupportedRatios().size(), 4);
+        expect (! Adapter::isRatioAllowed (48000.0, 0.5));
+        expect (Adapter::isRatioAllowed (48000.0, 8.0));
+        expect (! Adapter::isRatioAllowed (192000.0, 8.0), "Should disable ratios above 1 MHz");
+    }
+
+    void testBypass()
+    {
+        beginTest ("Bypass ratio");
+
+        Adapter adapter;
+        adapter.prepare ({ 48000.0, 1.0, 128, 2 });
+
+        expect (! adapter.isActive());
+        expectEquals (adapter.getProcessingSampleRate(), 48000.0);
+        expectEquals (adapter.getMaxProcessingBlockSize(), 128);
+        expectEquals (adapter.getLatencySamples(), 0);
+
+        juce::AudioBuffer<float> buffer (2, 32);
+        juce::MidiBuffer midi;
+        buffer.clear();
+
+        auto called = false;
+        const auto* channel0 = buffer.getReadPointer (0);
+        const auto* channel1 = buffer.getReadPointer (1);
+        const auto result = adapter.process (buffer, midi, [&] (auto& inner, auto&)
+        {
+            called = true;
+            expectEquals (inner.getNumSamples(), 32);
+            expect (inner.getReadPointer (0) == channel0);
+            expect (inner.getReadPointer (1) == channel1);
+            inner.setSample (0, 0, 0.25f);
+        });
+
+        expect (called);
+        expect (! result.active);
+        expectEquals (result.internalSamplesProcessed, 32);
+        expectWithinAbsoluteError (buffer.getSample (0, 0), 0.25f, 1.0e-7f);
+    }
+
+    void testOversamplingRatios()
+    {
+        beginTest ("2x, 4x, and 8x oversampling");
+
+        for (const auto ratio : { 2.0, 4.0, 8.0 })
+        {
+            Adapter adapter;
+            constexpr int maxBlock = 128;
+            adapter.prepare ({ 48000.0, ratio, maxBlock, 2 });
+
+            expect (adapter.isActive());
+            expectEquals (adapter.getProcessingSampleRate(), 48000.0 * ratio);
+            expectEquals (adapter.getMaxProcessingBlockSize(), maxBlock * (int) ratio);
+            expect (adapter.getLatencySamples() >= 0);
+
+            juce::AudioBuffer<float> buffer (2, maxBlock);
+            juce::MidiBuffer midi;
+            int64_t cursor = 0;
+
+            for (const auto blockSize : makeVariableBlocks (maxBlock, 96))
+            {
+                juce::AudioBuffer<float> block (buffer.getArrayOfWritePointers(), 2, blockSize);
+                fillRamp (block, cursor);
+
+                const auto result = adapter.process (block, midi, [this] (auto& inner, auto&)
+                {
+                    expect (inner.getNumSamples() > 0);
+                    inner.clear();
+                });
+
+                expect (result.active);
+                expectEquals (result.internalSamplesProcessed, blockSize * (int) ratio);
+            }
+        }
+    }
+
+    void testMidiMapping()
+    {
+        beginTest ("MIDI maps once and monotonically");
+
+        for (const auto ratio : { 2.0, 4.0, 8.0 })
+        {
+            Adapter adapter;
+            constexpr int maxBlock = 64;
+            adapter.prepare ({ 48000.0, ratio, maxBlock, 2 });
+
+            juce::AudioBuffer<float> buffer (2, maxBlock);
+            juce::MidiBuffer midi;
+            std::vector<int64_t> delivered;
+            auto internalCursor = (int64_t) 0;
+
+            for (int blockIndex = 0; blockIndex < 80; ++blockIndex)
+            {
+                const auto blockSize = makeVariableBlocks (maxBlock, 80)[(size_t) blockIndex];
+                juce::AudioBuffer<float> block (buffer.getArrayOfWritePointers(), 2, blockSize);
+                block.clear();
+                midi.clear();
+
+                if (blockIndex % 3 == 0)
+                    midi.addEvent (juce::MidiMessage::noteOn (1, 60, (juce::uint8) 100), blockSize / 2);
+
+                const auto before = internalCursor;
+                const auto result = adapter.process (block, midi, [&] (auto& inner, auto& internalMidi)
+                {
+                    for (const auto metadata : internalMidi)
+                        delivered.push_back (before + metadata.samplePosition);
+
+                    inner.clear();
+                });
+
+                internalCursor += result.internalSamplesProcessed;
+            }
+
+            expect (! delivered.empty());
+            for (size_t i = 1; i < delivered.size(); ++i)
+                expect (delivered[i] >= delivered[i - 1]);
+        }
+    }
+
+    void testOversizeBlockFailsSafely()
+    {
+        beginTest ("Oversize block fails safely");
+
+        Adapter adapter;
+        adapter.prepare ({ 48000.0, 2.0, 32, 2 });
+
+        juce::AudioBuffer<float> buffer (2, 33);
+        juce::MidiBuffer midi;
+        buffer.setSample (0, 0, 1.0f);
+
+        const auto result = adapter.process (buffer, midi, [] (auto&, auto&) {});
+        expect (result.active);
+        expectEquals (result.internalSamplesProcessed, 0);
+        expect (buffer.hasBeenCleared());
+    }
+};
+
+static IntegerRatioSampleRateAdapterTest integerRatioSampleRateAdapterTest;


### PR DESCRIPTION
## Summary

- add integer internal sample-rate ratios with MIDI remapping and reported latency
- expose the selector only in the osci-render standalone Audio menu
- keep DAW plugin instances and sosci on the existing 1x processing path
- persist the standalone ratio while defaulting old installs and projects to 1x

## Backwards compatibility

The default and unsupported path uses an inactive adapter and invokes the existing processing block directly. Existing project state does not need migration. Plugin instances cannot enable or expose the ratio, so host processing behavior remains unchanged.

## Dependency

This PR is stacked on the Lottie/animation PR so the review diff contains only internal sample-rate work. It can be retargeted to develop after that PR merges.

## Validation

- Integer Ratio Sample Rate Adapter DSP tests passed for validation, bypass, 2x/4x/8x processing, MIDI mapping, and oversized blocks
- osci-render Debug arm64 standalone build passed
- sosci Debug arm64 standalone build passed
- git diff --check