### PR TITLE
Fix MIDI-disabled startup and effect hover performance

### DIFF
--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -625,11 +625,10 @@ void OscirenderAudioProcessor::processBlockInternal(juce::AudioBuffer<float>& bu
 
     // if midi has just been disabled or we need to retrigger
     if (!usingMidi && (retriggerMidi || prevMidiEnabled)) {
-        if (voiceBuilder != nullptr && voiceBuilder->hasAnyVoiceReady()) {
+        retriggerMidi = true;
+        if (numSamples > 0 && voiceBuilder != nullptr && voiceBuilder->hasAnyVoiceReady()) {
             midiMessages.addEvent(juce::MidiMessage::noteOn(1, 60, 1.0f), juce::jmin(17, numSamples - 1));
             retriggerMidi = false;
-        } else {
-            retriggerMidi = true;
         }
     }
 
@@ -1434,10 +1433,6 @@ void OscirenderAudioProcessor::autoAssignLfosForPreview(const juce::String& effe
 void OscirenderAudioProcessor::clearPreviewLfoAssignments() {
     ScopedFlag suppress(undoSuppressed);
     lfoParameters.stopPreview();
-}
-
-void OscirenderAudioProcessor::promotePreviewLfoAssignments() {
-    lfoParameters.promotePreview();
 }
 
 juce::String OscirenderAudioProcessor::getParamDisplayName(const juce::String& paramId) const {

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -343,12 +343,14 @@ void VoiceBuilder::run() {
                 // Re-check: is this voice still needed?
                 if (targetCount.load(std::memory_order_acquire) > current) {
                     processor.synth.addVoice(voice); // internally locked
+                    readyVoiceCount.store(current + 1, std::memory_order_release);
                 } else {
                     delete voice;
                 }
             } else {
                 // Removal is cheap — just do it directly.
                 processor.synth.removeVoice(current - 1); // internally locked
+                readyVoiceCount.store(current - 1, std::memory_order_release);
             }
         }
     }
@@ -623,8 +625,12 @@ void OscirenderAudioProcessor::processBlockInternal(juce::AudioBuffer<float>& bu
 
     // if midi has just been disabled or we need to retrigger
     if (!usingMidi && (retriggerMidi || prevMidiEnabled)) {
-        midiMessages.addEvent(juce::MidiMessage::noteOn(1, 60, 1.0f), 17);
-        retriggerMidi = false;
+        if (voiceBuilder != nullptr && voiceBuilder->hasAnyVoiceReady()) {
+            midiMessages.addEvent(juce::MidiMessage::noteOn(1, 60, 1.0f), juce::jmin(17, numSamples - 1));
+            retriggerMidi = false;
+        } else {
+            retriggerMidi = true;
+        }
     }
 
     prevMidiEnabled = usingMidi;

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -1428,14 +1428,12 @@ void OscirenderAudioProcessor::convertFreeProjectLfos(const juce::XmlElement* ef
 
 void OscirenderAudioProcessor::autoAssignLfosForPreview(const juce::String& effectId) {
     ScopedFlag suppress(undoSuppressed);
-    lfoParameters.startPreview(effectId, toggleableEffects,
-                               [this](const osci::Effect& e) { removeAllAssignmentsForEffect(e); });
+    lfoParameters.startPreview(effectId, toggleableEffects);
 }
 
 void OscirenderAudioProcessor::clearPreviewLfoAssignments() {
     ScopedFlag suppress(undoSuppressed);
-    lfoParameters.stopPreview(toggleableEffects,
-                              [this](const osci::Effect& e) { removeAllAssignmentsForEffect(e); });
+    lfoParameters.stopPreview();
 }
 
 void OscirenderAudioProcessor::promotePreviewLfoAssignments() {

--- a/Source/PluginProcessor.h
+++ b/Source/PluginProcessor.h
@@ -202,7 +202,6 @@ public:
     void autoAssignLfosForEffect(osci::Effect& effect);
     void autoAssignLfosForPreview(const juce::String& effectId);
     void clearPreviewLfoAssignments();
-    void promotePreviewLfoAssignments();
 
 #if OSCI_PREMIUM
     // Convert per-parameter LFOs from a free project into global LFO assignments

--- a/Source/audio/modulation/LfoParameters.h
+++ b/Source/audio/modulation/LfoParameters.h
@@ -14,8 +14,6 @@
 // owns parameters and exposes vectors for the processor to adopt at construction.
 class LfoParameters : public ModulationSource {
 public:
-    enum class AutoAssignMode { persistent, preview };
-
     // DAW-automatable parameters (one per LFO)
     osci::FloatParameter* rate[NUM_LFOS] = {};
     LfoPresetParameter* preset[NUM_LFOS] = {};
@@ -451,8 +449,7 @@ public:
 
     // Automatically assign LFOs to modulate the parameters of an effect,
     // based on each parameter's lfoTypeDefault and lfoRateDefault.
-    void autoAssignForEffect(osci::Effect& effect, AutoAssignMode mode = AutoAssignMode::persistent) {
-        const bool isPreview = mode == AutoAssignMode::preview;
+    void autoAssignForEffect(osci::Effect& effect, bool isPreview = false) {
         std::vector<LfoAssignment> currentAssignments = getAssignments();
 
         int assignmentCount[NUM_LFOS] = {};
@@ -619,7 +616,7 @@ public:
                     }
                 }
 
-                autoAssignForEffect(*eff, AutoAssignMode::preview);
+                autoAssignForEffect(*eff, true);
                 break;
             }
         }

--- a/Source/audio/modulation/LfoParameters.h
+++ b/Source/audio/modulation/LfoParameters.h
@@ -657,24 +657,6 @@ public:
     // Promote preview: keep assignments and param values, just clear preview tracking.
     void promotePreview() {
         jassert(juce::MessageManager::getInstance()->isThisTheMessageThread());
-        for (const auto& saved : previewSavedParamValues) {
-            auto* param = saved.first;
-            const float currentValue = param->getValueUnnormalised();
-            if (currentValue != saved.second) {
-                param->setUnnormalisedValueNotifyingHost(currentValue);
-            }
-        }
-        for (const auto& saved : previewSavedLfoStates) {
-            auto* presetParam = preset[saved.lfoIndex];
-            const auto currentPreset = static_cast<LfoPreset>(presetParam->getValueUnnormalised());
-            if (currentPreset != saved.preset) {
-                presetParam->setUnnormalisedValueNotifyingHost(static_cast<float>(currentPreset));
-            }
-            auto* rateParam = rate[saved.lfoIndex];
-            if (rateParam != nullptr && rateParam->getValueUnnormalised() != saved.rateValue) {
-                rateParam->setUnnormalisedValueNotifyingHost(rateParam->getValueUnnormalised());
-            }
-        }
         resetPreviewState();
     }
 };

--- a/Source/audio/modulation/LfoParameters.h
+++ b/Source/audio/modulation/LfoParameters.h
@@ -654,9 +654,4 @@ public:
         resetPreviewState();
     }
 
-    // Promote preview: keep assignments and param values, just clear preview tracking.
-    void promotePreview() {
-        jassert(juce::MessageManager::getInstance()->isThisTheMessageThread());
-        resetPreviewState();
-    }
 };

--- a/Source/audio/modulation/LfoParameters.h
+++ b/Source/audio/modulation/LfoParameters.h
@@ -14,6 +14,8 @@
 // owns parameters and exposes vectors for the processor to adopt at construction.
 class LfoParameters : public ModulationSource {
 public:
+    enum class AutoAssignMode { persistent, preview };
+
     // DAW-automatable parameters (one per LFO)
     osci::FloatParameter* rate[NUM_LFOS] = {};
     LfoPresetParameter* preset[NUM_LFOS] = {};
@@ -47,6 +49,8 @@ public:
     std::atomic<bool> customState[NUM_LFOS] = {};  // true when LFO waveform is user-modified
 
     LfoParameters() {
+        previewSavedLfoStates.reserve(NUM_LFOS);
+
         for (int i = 0; i < NUM_LFOS; ++i) {
             juce::String idx = juce::String(i + 1);
             juce::String pfx = "lfo" + idx;
@@ -447,7 +451,8 @@ public:
 
     // Automatically assign LFOs to modulate the parameters of an effect,
     // based on each parameter's lfoTypeDefault and lfoRateDefault.
-    void autoAssignForEffect(osci::Effect& effect) {
+    void autoAssignForEffect(osci::Effect& effect, AutoAssignMode mode = AutoAssignMode::persistent) {
+        const bool isPreview = mode == AutoAssignMode::preview;
         std::vector<LfoAssignment> currentAssignments = getAssignments();
 
         int assignmentCount[NUM_LFOS] = {};
@@ -490,13 +495,26 @@ public:
         };
 
         auto configureLfo = [&](int lfoIdx, LfoPreset desiredPreset, float desiredRate, int score) {
+            if (isPreview && score <= 3) {
+                savePreviewLfoState(lfoIdx, score <= 2);
+            }
             if (score <= 2) {
+                if (isPreview) {
+                    preset[lfoIdx]->setValueUnnormalised(static_cast<float>(desiredPreset));
+                } else {
+                    setPreset(lfoIdx, desiredPreset);
+                }
+                auto replacement = createLfoPreset(desiredPreset);
                 juce::SpinLock::ScopedLockType lock(waveformLock);
-                setPreset(lfoIdx, desiredPreset);
-                waveforms[lfoIdx] = createLfoPreset(desiredPreset);
+                std::swap(waveforms[lfoIdx].nodes, replacement.nodes);
+                std::swap(waveforms[lfoIdx].smooth, replacement.smooth);
             }
             if (score <= 3 && rate[lfoIdx] != nullptr) {
-                rate[lfoIdx]->setUnnormalisedValueNotifyingHost(desiredRate);
+                if (isPreview) {
+                    rate[lfoIdx]->setValueUnnormalised(desiredRate);
+                } else {
+                    rate[lfoIdx]->setUnnormalisedValueNotifyingHost(desiredRate);
+                }
             }
         };
 
@@ -523,7 +541,11 @@ public:
             }
             configureLfo(chosenLfo, desiredPreset, desiredRate, score);
 
-            param->setUnnormalisedValueNotifyingHost(param->min.load());
+            if (isPreview) {
+                param->setValueUnnormalised(param->min.load());
+            } else {
+                param->setUnnormalisedValueNotifyingHost(param->min.load());
+            }
 
             LfoAssignment assignment;
             assignment.sourceIndex = chosenLfo;
@@ -540,94 +562,118 @@ public:
     // Temporarily auto-assigns LFOs while hovering an effect in the grid.
 
     // Preview state (message-thread only — no lock needed)
-    juce::String previewEffectId;
-    std::vector<std::pair<juce::String, float>> previewSavedParamValues;
+    std::vector<std::pair<osci::EffectParameter*, float>> previewSavedParamValues;
+    std::vector<LfoAssignment> previewSavedAssignments;
 
     struct SavedLfoState {
         int lfoIndex;
         LfoPreset preset;
-        LfoWaveform waveform;
-        bool isCustom;
+        std::optional<LfoWaveform> waveform;
         float rateValue;
     };
     std::vector<SavedLfoState> previewSavedLfoStates;
 
+    void savePreviewLfoState(int lfoIndex, bool saveWaveform) {
+        auto saved = std::find_if(previewSavedLfoStates.begin(), previewSavedLfoStates.end(),
+                                  [lfoIndex](const SavedLfoState& state) { return state.lfoIndex == lfoIndex; });
+        if (saved == previewSavedLfoStates.end()) {
+            previewSavedLfoStates.push_back({ lfoIndex, getPreset(lfoIndex), std::nullopt,
+                                              rate[lfoIndex] != nullptr ? rate[lfoIndex]->getValueUnnormalised() : 1.0f });
+            saved = std::prev(previewSavedLfoStates.end());
+        }
+        if (saveWaveform && !saved->waveform.has_value()) {
+            juce::SpinLock::ScopedLockType lock(waveformLock);
+            saved->waveform = waveforms[lfoIndex];
+        }
+    }
+
+    void resetPreviewState() {
+        previewSavedParamValues.clear();
+        previewSavedAssignments.clear();
+        previewSavedLfoStates.clear();
+    }
+
+    bool isPreviewParameter(const LfoAssignment& assignment) const {
+        return std::any_of(previewSavedParamValues.begin(), previewSavedParamValues.end(),
+                           [&assignment](const auto& saved) { return saved.first->paramID == assignment.paramId; });
+    }
+
     // Start previewing: save current param values, auto-assign LFOs to the effect.
-    void startPreview(const juce::String& effectId,
-                      const std::vector<std::shared_ptr<osci::Effect>>& effects,
-                      std::function<void(const osci::Effect&)> removeAllAssignments) {
+    void startPreview(const juce::String& effectId, const std::vector<std::shared_ptr<osci::Effect>>& effects) {
         jassert(juce::MessageManager::getInstance()->isThisTheMessageThread());
-        stopPreview(effects, removeAllAssignments);
+        stopPreview();
         for (auto& eff : effects) {
             if (eff->getId() == effectId) {
-                previewSavedParamValues.clear();
-                previewSavedLfoStates.clear();
+                previewSavedParamValues.reserve(eff->parameters.size());
 
                 // Save param values
                 for (auto* param : eff->parameters) {
-                    if (param->lfoTypeDefault != osci::LfoType::Static)
-                        previewSavedParamValues.emplace_back(param->paramID, param->getValueUnnormalised());
+                    if (param->lfoTypeDefault != osci::LfoType::Static) {
+                        previewSavedParamValues.emplace_back(param, param->getValueUnnormalised());
+                    }
                 }
 
-                // Save LFO waveform/preset state for all LFOs (before auto-assign modifies them)
-                previewSavedLfoStates.reserve(NUM_LFOS);
-                for (int i = 0; i < NUM_LFOS; ++i) {
-                    juce::SpinLock::ScopedLockType lock(waveformLock);
-                    previewSavedLfoStates.push_back({
-                        i, getPreset(i), waveforms[i], getIsCustom(i),
-                        rate[i] != nullptr ? rate[i]->getValueUnnormalised() : 1.0f
-                    });
+                for (const auto& assignment : getAssignments()) {
+                    if (isPreviewParameter(assignment)) {
+                        previewSavedAssignments.push_back(assignment);
+                    }
                 }
 
-                autoAssignForEffect(*eff);
-                previewEffectId = effectId;
+                autoAssignForEffect(*eff, AutoAssignMode::preview);
                 break;
             }
         }
     }
 
     // Stop previewing: remove assignments and restore saved parameter values.
-    void stopPreview(const std::vector<std::shared_ptr<osci::Effect>>& effects,
-                     std::function<void(const osci::Effect&)> removeAllAssignments) {
+    void stopPreview() {
         jassert(juce::MessageManager::getInstance()->isThisTheMessageThread());
-        if (previewEffectId.isEmpty()) return;
-        for (auto& eff : effects) {
-            if (eff->getId() == previewEffectId) {
-                removeAllAssignments(*eff);
-                for (const auto& [paramId, savedValue] : previewSavedParamValues) {
-                    for (auto* param : eff->parameters) {
-                        if (param->paramID == paramId) {
-                            param->setUnnormalisedValueNotifyingHost(savedValue);
-                            break;
-                        }
-                    }
-                }
-                break;
-            }
+        removeAssignmentsIf([this](const LfoAssignment& assignment) { return isPreviewParameter(assignment); });
+        for (const auto& assignment : previewSavedAssignments) {
+            addAssignment(assignment);
         }
 
-        // Restore LFO waveform/preset states
-        for (const auto& saved : previewSavedLfoStates) {
-            {
+        for (const auto& [param, savedValue] : previewSavedParamValues) {
+            param->setValueUnnormalised(savedValue);
+        }
+
+        // Restore only the LFO state changed by auto-assignment.
+        for (auto& saved : previewSavedLfoStates) {
+            preset[saved.lfoIndex]->setValueUnnormalised(static_cast<float>(saved.preset));
+            if (saved.waveform.has_value()) {
                 juce::SpinLock::ScopedLockType lock(waveformLock);
-                setPreset(saved.lfoIndex, saved.preset);
-                waveforms[saved.lfoIndex] = saved.waveform;
-                setIsCustom(saved.lfoIndex, saved.isCustom);
+                std::swap(waveforms[saved.lfoIndex].nodes, saved.waveform->nodes);
+                std::swap(waveforms[saved.lfoIndex].smooth, saved.waveform->smooth);
             }
-            if (rate[saved.lfoIndex] != nullptr)
-                rate[saved.lfoIndex]->setUnnormalisedValueNotifyingHost(saved.rateValue);
+            if (rate[saved.lfoIndex] != nullptr) {
+                rate[saved.lfoIndex]->setValueUnnormalised(saved.rateValue);
+            }
         }
 
-        previewSavedParamValues.clear();
-        previewSavedLfoStates.clear();
-        previewEffectId = juce::String();
+        resetPreviewState();
     }
 
     // Promote preview: keep assignments and param values, just clear preview tracking.
     void promotePreview() {
         jassert(juce::MessageManager::getInstance()->isThisTheMessageThread());
-        previewSavedParamValues.clear();
-        previewSavedLfoStates.clear();
-        previewEffectId = juce::String();
+        for (const auto& saved : previewSavedParamValues) {
+            auto* param = saved.first;
+            const float currentValue = param->getValueUnnormalised();
+            if (currentValue != saved.second) {
+                param->setUnnormalisedValueNotifyingHost(currentValue);
+            }
+        }
+        for (const auto& saved : previewSavedLfoStates) {
+            auto* presetParam = preset[saved.lfoIndex];
+            const auto currentPreset = static_cast<LfoPreset>(presetParam->getValueUnnormalised());
+            if (currentPreset != saved.preset) {
+                presetParam->setUnnormalisedValueNotifyingHost(static_cast<float>(currentPreset));
+            }
+            auto* rateParam = rate[saved.lfoIndex];
+            if (rateParam != nullptr && rateParam->getValueUnnormalised() != saved.rateValue) {
+                rateParam->setUnnormalisedValueNotifyingHost(rateParam->getValueUnnormalised());
+            }
+        }
+        resetPreviewState();
     }
 };

--- a/Source/audio/modulation/LfoParameters.h
+++ b/Source/audio/modulation/LfoParameters.h
@@ -628,7 +628,11 @@ public:
     // Stop previewing: remove assignments and restore saved parameter values.
     void stopPreview() {
         jassert(juce::MessageManager::getInstance()->isThisTheMessageThread());
-        removeAssignmentsIf([this](const LfoAssignment& assignment) { return isPreviewParameter(assignment); });
+        for (const auto& assignment : getAssignments()) {
+            if (isPreviewParameter(assignment)) {
+                removeAssignment(assignment.sourceIndex, assignment.paramId);
+            }
+        }
         for (const auto& assignment : previewSavedAssignments) {
             addAssignment(assignment);
         }

--- a/Source/audio/modulation/ModulationAssignmentStore.h
+++ b/Source/audio/modulation/ModulationAssignmentStore.h
@@ -45,13 +45,6 @@ struct ModulationAssignmentStore {
         dest = items;
     }
 
-    // Remove all assignments matching a predicate
-    template<typename Pred>
-    void removeIf(Pred pred) {
-        juce::SpinLock::ScopedLockType scopedLock(lock);
-        items.erase(std::remove_if(items.begin(), items.end(), pred), items.end());
-    }
-
     void clear() {
         juce::SpinLock::ScopedLockType scopedLock(lock);
         items.clear();

--- a/Source/audio/modulation/ModulationSource.h
+++ b/Source/audio/modulation/ModulationSource.h
@@ -62,9 +62,6 @@ public:
         return cachedAssignments;
     }
 
-    template<typename Pred>
-    void removeAssignmentsIf(Pred pred) { assignments.removeIf(pred); }
-
     // === Block buffers (filled by type-specific code each processBlock) ===
     virtual const std::vector<float>* getBlockBuffers() const = 0;
 

--- a/Source/audio/synth/ShapeVoice.cpp
+++ b/Source/audio/synth/ShapeVoice.cpp
@@ -26,16 +26,9 @@ void ShapeVoice::initializeEffectsFromGlobal() {
 }
 
 void ShapeVoice::setPreviewEffect(std::shared_ptr<osci::SimpleEffect> effect) {
-    if (effect) {
-        voicePreviewEffect = effect->cloneWithSharedParameters();
-        // Initialize the effect with current sample rate
-        const double sampleRate = audioProcessor.getEffectiveSampleRate();
-        if (sampleRate > 0) {
-            voicePreviewEffect->prepareToPlay(sampleRate, 512);
-        }
-    } else {
-        voicePreviewEffect = nullptr;
-    }
+    // Reuse the normal effect instance so enabling it preserves its preview DSP state.
+    auto existingEffect = effect != nullptr ? voiceEffectsMap.find(effect->getId()) : voiceEffectsMap.end();
+    voicePreviewEffect = existingEffect != voiceEffectsMap.end() ? existingEffect->second : nullptr;
 }
 
 void ShapeVoice::clearPreviewEffect() {
@@ -46,10 +39,6 @@ void ShapeVoice::prepareToPlay(double sampleRate, int samplesPerBlock) {
     // Update sample rate for all voice effects
     for (auto& pair : voiceEffectsMap) {
         pair.second->prepareToPlay(sampleRate, samplesPerBlock);
-    }
-    // Update sample rate for preview effect if set
-    if (voicePreviewEffect) {
-        voicePreviewEffect->prepareToPlay(sampleRate, samplesPerBlock);
     }
 }
 

--- a/Source/audio/synth/ShapeVoice.cpp
+++ b/Source/audio/synth/ShapeVoice.cpp
@@ -26,9 +26,16 @@ void ShapeVoice::initializeEffectsFromGlobal() {
 }
 
 void ShapeVoice::setPreviewEffect(std::shared_ptr<osci::SimpleEffect> effect) {
-    // Reuse the normal effect instance so enabling it preserves its preview DSP state.
-    auto existingEffect = effect != nullptr ? voiceEffectsMap.find(effect->getId()) : voiceEffectsMap.end();
-    voicePreviewEffect = existingEffect != voiceEffectsMap.end() ? existingEffect->second : nullptr;
+    if (effect) {
+        voicePreviewEffect = effect->cloneWithSharedParameters();
+        // Initialize the effect with current sample rate
+        const double sampleRate = audioProcessor.getEffectiveSampleRate();
+        if (sampleRate > 0) {
+            voicePreviewEffect->prepareToPlay(sampleRate, 512);
+        }
+    } else {
+        voicePreviewEffect = nullptr;
+    }
 }
 
 void ShapeVoice::clearPreviewEffect() {
@@ -39,6 +46,10 @@ void ShapeVoice::prepareToPlay(double sampleRate, int samplesPerBlock) {
     // Update sample rate for all voice effects
     for (auto& pair : voiceEffectsMap) {
         pair.second->prepareToPlay(sampleRate, samplesPerBlock);
+    }
+    // Update sample rate for preview effect if set
+    if (voicePreviewEffect) {
+        voicePreviewEffect->prepareToPlay(sampleRate, samplesPerBlock);
     }
 }
 

--- a/Source/audio/synth/ShapeVoice.cpp
+++ b/Source/audio/synth/ShapeVoice.cpp
@@ -26,16 +26,8 @@ void ShapeVoice::initializeEffectsFromGlobal() {
 }
 
 void ShapeVoice::setPreviewEffect(std::shared_ptr<osci::SimpleEffect> effect) {
-    if (effect) {
-        voicePreviewEffect = effect->cloneWithSharedParameters();
-        // Initialize the effect with current sample rate
-        const double sampleRate = audioProcessor.getEffectiveSampleRate();
-        if (sampleRate > 0) {
-            voicePreviewEffect->prepareToPlay(sampleRate, 512);
-        }
-    } else {
-        voicePreviewEffect = nullptr;
-    }
+    auto existingEffect = effect != nullptr ? voiceEffectsMap.find(effect->getId()) : voiceEffectsMap.end();
+    voicePreviewEffect = existingEffect != voiceEffectsMap.end() ? existingEffect->second : nullptr;
 }
 
 void ShapeVoice::clearPreviewEffect() {
@@ -46,10 +38,6 @@ void ShapeVoice::prepareToPlay(double sampleRate, int samplesPerBlock) {
     // Update sample rate for all voice effects
     for (auto& pair : voiceEffectsMap) {
         pair.second->prepareToPlay(sampleRate, samplesPerBlock);
-    }
-    // Update sample rate for preview effect if set
-    if (voicePreviewEffect) {
-        voicePreviewEffect->prepareToPlay(sampleRate, samplesPerBlock);
     }
 }
 

--- a/Source/audio/synth/VoiceBuilder.h
+++ b/Source/audio/synth/VoiceBuilder.h
@@ -23,6 +23,10 @@ public:
         notify();
     }
 
+    bool hasAnyVoiceReady() const noexcept {
+        return readyVoiceCount.load(std::memory_order_acquire) > 0;
+    }
+
     // Defined out-of-line in PluginProcessor.cpp because run() needs
     // the full OscirenderAudioProcessor definition.
     void run() override;
@@ -30,4 +34,5 @@ public:
 private:
     OscirenderAudioProcessor& processor;
     std::atomic<int> targetCount{0};
+    std::atomic<int> readyVoiceCount{0};
 };

--- a/Source/components/effects/EffectTypeGridComponent.cpp
+++ b/Source/components/effects/EffectTypeGridComponent.cpp
@@ -82,24 +82,34 @@ void EffectTypeGridComponent::setupEffectItems()
                     onEffectSelected(effectId);
             };
             item->onHoverStart = [this](const juce::String& effectId) {
-                if (audioProcessor.globalSettings.getBool("previewEffectOnHover", true)) {
+                if (!audioProcessor.globalSettings.getBool("previewEffectOnHover", true)) {
+                    return;
+                }
+
+                {
                     juce::SpinLock::ScopedLockType lock(audioProcessor.effectsLock);
                     audioProcessor.setPreviewEffectId(effectId);
                 }
+                hoverPreviewActive = true;
 #if OSCI_PREMIUM
                 if (audioProcessor.globalSettings.getBool("autoLinkLfos", true)) {
                     audioProcessor.autoAssignLfosForPreview(effectId);
-                    audioProcessor.broadcaster.sendChangeMessage();
                 }
 #endif
             };
             item->onHoverEnd = [this]() {
-                if (audioProcessor.globalSettings.getBool("previewEffectOnHover", true)) {
+                if (!hoverPreviewActive) {
+                    return;
+                }
+                hoverPreviewActive = false;
+
+                {
                     juce::SpinLock::ScopedLockType lock(audioProcessor.effectsLock);
                     audioProcessor.clearPreviewEffect();
                 }
+#if OSCI_PREMIUM
                 audioProcessor.clearPreviewLfoAssignments();
-                audioProcessor.broadcaster.sendChangeMessage();
+#endif
             };
         }
 

--- a/Source/components/effects/EffectTypeGridComponent.h
+++ b/Source/components/effects/EffectTypeGridComponent.h
@@ -24,6 +24,7 @@ private:
     OscirenderAudioProcessorEditor& editor;
     osci::GridComponent grid;
     juce::TextButton cancelButton { "Cancel" };
+    bool hoverPreviewActive = false;
 
     void setupEffectItems();
 

--- a/Source/components/effects/EffectsListComponent.h
+++ b/Source/components/effects/EffectsListComponent.h
@@ -17,6 +17,7 @@ struct AudioEffectListBoxItemData : public DraggableListBoxItemData
     std::function<void()> onAddNewEffectRequested; // callback hooked by parent to open the grid
 
     AudioEffectListBoxItemData(OscirenderAudioProcessor& p, OscirenderAudioProcessorEditor& editor) : audioProcessor(p), editor(editor) {
+        data.reserve(audioProcessor.toggleableEffects.size());
         resetData();
     }
 

--- a/Source/components/menu/OsciMainMenuBarModel.cpp
+++ b/Source/components/menu/OsciMainMenuBarModel.cpp
@@ -234,8 +234,11 @@ void OsciMainMenuBarModel::resetMenuItems() {
         audioProcessor.globalSettings.set("previewEffectOnHover", newValue);
         audioProcessor.globalSettings.save();
         if (!newValue) {
-            juce::SpinLock::ScopedLockType lock(audioProcessor.effectsLock);
-            audioProcessor.clearPreviewEffect();
+            {
+                juce::SpinLock::ScopedLockType lock(audioProcessor.effectsLock);
+                audioProcessor.clearPreviewEffect();
+            }
+            audioProcessor.clearPreviewLfoAssignments();
         }
         resetMenuItems(); // update tick state
         }, [this] { return audioProcessor.globalSettings.getBool("previewEffectOnHover", true);

--- a/Source/components/panels/EffectsComponent.cpp
+++ b/Source/components/panels/EffectsComponent.cpp
@@ -78,8 +78,8 @@ EffectsComponent::EffectsComponent(OscirenderAudioProcessor& p, OscirenderAudioP
         {
         CommonAudioProcessor::ScopedFlag grouping(audioProcessor.undoGrouping);
 
-        // Find the chosen effect (read-only under lock)
         {
+            // Keep the preview-to-enabled transition atomic for the audio thread.
             juce::SpinLock::ScopedLockType lock(audioProcessor.effectsLock);
             for (auto& eff : audioProcessor.toggleableEffects) {
                 if (eff->getId() == effectId) {
@@ -87,21 +87,26 @@ EffectsComponent::EffectsComponent(OscirenderAudioProcessor& p, OscirenderAudioP
                     break;
                 }
             }
+
+            if (chosen != nullptr) {
+                chosen->selected->setBoolValue(true);
+                chosen->enabled->setBoolValue(true);
+
+                // Keep the enabled effect last, matching its preview position.
+                int idx = 0;
+                for (auto& e : itemData.data) {
+                    if (e != chosen) {
+                        e->setPrecedence(idx++);
+                    }
+                }
+                chosen->setPrecedence(idx++);
+                audioProcessor.updateEffectPrecedence();
+            }
         }
-        // Set parameters OUTSIDE the SpinLock (they do ValueTree/UndoManager work)
+        // Persist and notify after the audio-visible transition is complete.
         if (chosen != nullptr) {
             chosen->selected->setBoolValueNotifyingHost(true);
             chosen->enabled->setBoolValueNotifyingHost(true);
-        }
-        // Place chosen effect at the end of the visible (selected) list and update precedence
-        if (chosen != nullptr) {
-            juce::SpinLock::ScopedLockType lock(audioProcessor.effectsLock);
-            int idx = 0;
-            for (auto& e : itemData.data) {
-                if (e != chosen) e->setPrecedence(idx++);
-            }
-            chosen->setPrecedence(idx++);
-            audioProcessor.updateEffectPrecedence();
         }
         // Promote any preview LFO assignments so hover-end won't remove them
         audioProcessor.promotePreviewLfoAssignments();

--- a/Source/components/panels/EffectsComponent.cpp
+++ b/Source/components/panels/EffectsComponent.cpp
@@ -106,6 +106,7 @@ EffectsComponent::EffectsComponent(OscirenderAudioProcessor& p, OscirenderAudioP
         if (chosen != nullptr) {
             chosen->selected->setBoolValueNotifyingHost(true);
             chosen->enabled->setBoolValueNotifyingHost(true);
+            paramSync.cancelPendingUpdate();
         }
         // Promote any preview LFO assignments so hover-end won't remove them
         audioProcessor.promotePreviewLfoAssignments();
@@ -113,12 +114,13 @@ EffectsComponent::EffectsComponent(OscirenderAudioProcessor& p, OscirenderAudioP
 #if OSCI_PREMIUM
         if (chosen != nullptr && audioProcessor.globalSettings.getBool("autoLinkLfos", true)) {
             audioProcessor.autoAssignLfosForEffect(*chosen);
-            audioProcessor.broadcaster.sendChangeMessage();
         }
 #endif
         }
-        // Refresh list content to include newly selected
-        itemData.resetData();
+        // The chosen effect already has the final precedence and belongs at the end.
+        if (chosen != nullptr) {
+            itemData.data.push_back(chosen);
+        }
         listBox.updateContent();
         showingGrid = false;
         listBox.setVisible(true);

--- a/Source/components/panels/EffectsComponent.cpp
+++ b/Source/components/panels/EffectsComponent.cpp
@@ -78,8 +78,8 @@ EffectsComponent::EffectsComponent(OscirenderAudioProcessor& p, OscirenderAudioP
         {
         CommonAudioProcessor::ScopedFlag grouping(audioProcessor.undoGrouping);
 
+        // Find the chosen effect (read-only under lock)
         {
-            // Keep the preview-to-enabled transition atomic for the audio thread.
             juce::SpinLock::ScopedLockType lock(audioProcessor.effectsLock);
             for (auto& eff : audioProcessor.toggleableEffects) {
                 if (eff->getId() == effectId) {
@@ -87,26 +87,21 @@ EffectsComponent::EffectsComponent(OscirenderAudioProcessor& p, OscirenderAudioP
                     break;
                 }
             }
-
-            if (chosen != nullptr) {
-                chosen->selected->setBoolValue(true);
-                chosen->enabled->setBoolValue(true);
-
-                // Keep the enabled effect last, matching its preview position.
-                int idx = 0;
-                for (auto& e : itemData.data) {
-                    if (e != chosen) {
-                        e->setPrecedence(idx++);
-                    }
-                }
-                chosen->setPrecedence(idx++);
-                audioProcessor.updateEffectPrecedence();
-            }
         }
-        // Persist and notify after the audio-visible transition is complete.
+        // Set parameters OUTSIDE the SpinLock (they do ValueTree/UndoManager work)
         if (chosen != nullptr) {
             chosen->selected->setBoolValueNotifyingHost(true);
             chosen->enabled->setBoolValueNotifyingHost(true);
+        }
+        // Place chosen effect at the end of the visible (selected) list and update precedence
+        if (chosen != nullptr) {
+            juce::SpinLock::ScopedLockType lock(audioProcessor.effectsLock);
+            int idx = 0;
+            for (auto& e : itemData.data) {
+                if (e != chosen) e->setPrecedence(idx++);
+            }
+            chosen->setPrecedence(idx++);
+            audioProcessor.updateEffectPrecedence();
         }
         // Promote any preview LFO assignments so hover-end won't remove them
         audioProcessor.promotePreviewLfoAssignments();

--- a/Source/components/panels/EffectsComponent.cpp
+++ b/Source/components/panels/EffectsComponent.cpp
@@ -76,45 +76,43 @@ EffectsComponent::EffectsComponent(OscirenderAudioProcessor& p, OscirenderAudioP
         auto& um = audioProcessor.getUndoManager();
         um.beginNewTransaction("Add Effect");
         {
-        CommonAudioProcessor::ScopedFlag grouping(audioProcessor.undoGrouping);
+            CommonAudioProcessor::ScopedFlag grouping(audioProcessor.undoGrouping);
 
-        {
-            juce::SpinLock::ScopedLockType lock(audioProcessor.effectsLock);
-            for (auto& eff : audioProcessor.toggleableEffects) {
-                if (eff->getId() == effectId) {
-                    chosen = eff;
-                    break;
-                }
-            }
-
-            if (chosen != nullptr) {
-                chosen->selected->setBoolValue(true);
-                chosen->enabled->setBoolValue(true);
-
-                int idx = 0;
-                for (auto& effect : itemData.data) {
-                    if (effect != chosen) {
-                        effect->setPrecedence(idx++);
+            {
+                juce::SpinLock::ScopedLockType lock(audioProcessor.effectsLock);
+                for (auto& eff : audioProcessor.toggleableEffects) {
+                    if (eff->getId() == effectId) {
+                        chosen = eff;
+                        break;
                     }
                 }
-                chosen->setPrecedence(idx);
-                audioProcessor.updateEffectPrecedence();
-            }
-        }
 
-        // Persist and notify outside the audio-thread lock.
-        if (chosen != nullptr) {
-            chosen->selected->setBoolValueNotifyingHost(true);
-            chosen->enabled->setBoolValueNotifyingHost(true);
-            paramSync.cancelPendingUpdate();
-        }
-        // Promote any preview LFO assignments so hover-end won't remove them
-        audioProcessor.promotePreviewLfoAssignments();
-        // Auto-assign LFOs if the toggle is enabled
+                if (chosen != nullptr) {
+                    chosen->selected->setBoolValue(true);
+                    chosen->enabled->setBoolValue(true);
+
+                    int idx = 0;
+                    for (auto& effect : itemData.data) {
+                        if (effect != chosen) {
+                            effect->setPrecedence(idx++);
+                        }
+                    }
+                    chosen->setPrecedence(idx);
+                    audioProcessor.updateEffectPrecedence();
+                }
+            }
+
+            // Persist and notify outside the audio-thread lock.
+            if (chosen != nullptr) {
+                ParameterSyncHelper::ScopedUpdateSuppression suppressListRefresh(paramSync);
+                chosen->selected->setBoolValueNotifyingHost(true);
+                chosen->enabled->setBoolValueNotifyingHost(true);
+            }
+            // Auto-assign LFOs if the toggle is enabled.
 #if OSCI_PREMIUM
-        if (chosen != nullptr && audioProcessor.globalSettings.getBool("autoLinkLfos", true)) {
-            audioProcessor.autoAssignLfosForEffect(*chosen);
-        }
+            if (chosen != nullptr && audioProcessor.globalSettings.getBool("autoLinkLfos", true)) {
+                audioProcessor.autoAssignLfosForEffect(*chosen);
+            }
 #endif
         }
         // The chosen effect already has the final precedence and belongs at the end.

--- a/Source/components/panels/EffectsComponent.cpp
+++ b/Source/components/panels/EffectsComponent.cpp
@@ -78,7 +78,6 @@ EffectsComponent::EffectsComponent(OscirenderAudioProcessor& p, OscirenderAudioP
         {
         CommonAudioProcessor::ScopedFlag grouping(audioProcessor.undoGrouping);
 
-        // Find the chosen effect (read-only under lock)
         {
             juce::SpinLock::ScopedLockType lock(audioProcessor.effectsLock);
             for (auto& eff : audioProcessor.toggleableEffects) {
@@ -87,21 +86,26 @@ EffectsComponent::EffectsComponent(OscirenderAudioProcessor& p, OscirenderAudioP
                     break;
                 }
             }
+
+            if (chosen != nullptr) {
+                chosen->selected->setBoolValue(true);
+                chosen->enabled->setBoolValue(true);
+
+                int idx = 0;
+                for (auto& effect : itemData.data) {
+                    if (effect != chosen) {
+                        effect->setPrecedence(idx++);
+                    }
+                }
+                chosen->setPrecedence(idx);
+                audioProcessor.updateEffectPrecedence();
+            }
         }
-        // Set parameters OUTSIDE the SpinLock (they do ValueTree/UndoManager work)
+
+        // Persist and notify outside the audio-thread lock.
         if (chosen != nullptr) {
             chosen->selected->setBoolValueNotifyingHost(true);
             chosen->enabled->setBoolValueNotifyingHost(true);
-        }
-        // Place chosen effect at the end of the visible (selected) list and update precedence
-        if (chosen != nullptr) {
-            juce::SpinLock::ScopedLockType lock(audioProcessor.effectsLock);
-            int idx = 0;
-            for (auto& e : itemData.data) {
-                if (e != chosen) e->setPrecedence(idx++);
-            }
-            chosen->setPrecedence(idx++);
-            audioProcessor.updateEffectPrecedence();
         }
         // Promote any preview LFO assignments so hover-end won't remove them
         audioProcessor.promotePreviewLfoAssignments();

--- a/Source/components/panels/EffectsComponent.cpp
+++ b/Source/components/panels/EffectsComponent.cpp
@@ -78,6 +78,7 @@ EffectsComponent::EffectsComponent(OscirenderAudioProcessor& p, OscirenderAudioP
         {
         CommonAudioProcessor::ScopedFlag grouping(audioProcessor.undoGrouping);
 
+        // Find the chosen effect (read-only under lock)
         {
             juce::SpinLock::ScopedLockType lock(audioProcessor.effectsLock);
             for (auto& eff : audioProcessor.toggleableEffects) {
@@ -86,26 +87,21 @@ EffectsComponent::EffectsComponent(OscirenderAudioProcessor& p, OscirenderAudioP
                     break;
                 }
             }
-
-            if (chosen != nullptr) {
-                chosen->selected->setBoolValue(true);
-                chosen->enabled->setBoolValue(true);
-
-                int idx = 0;
-                for (auto& effect : itemData.data) {
-                    if (effect != chosen) {
-                        effect->setPrecedence(idx++);
-                    }
-                }
-                chosen->setPrecedence(idx);
-                audioProcessor.updateEffectPrecedence();
-            }
         }
-
-        // Persist and notify outside the audio-thread lock.
+        // Set parameters OUTSIDE the SpinLock (they do ValueTree/UndoManager work)
         if (chosen != nullptr) {
             chosen->selected->setBoolValueNotifyingHost(true);
             chosen->enabled->setBoolValueNotifyingHost(true);
+        }
+        // Place chosen effect at the end of the visible (selected) list and update precedence
+        if (chosen != nullptr) {
+            juce::SpinLock::ScopedLockType lock(audioProcessor.effectsLock);
+            int idx = 0;
+            for (auto& e : itemData.data) {
+                if (e != chosen) e->setPrecedence(idx++);
+            }
+            chosen->setPrecedence(idx++);
+            audioProcessor.updateEffectPrecedence();
         }
         // Promote any preview LFO assignments so hover-end won't remove them
         audioProcessor.promotePreviewLfoAssignments();

--- a/tests/LfoStressTest.cpp
+++ b/tests/LfoStressTest.cpp
@@ -1,4 +1,6 @@
 #include <JuceHeader.h>
+#include "TestCleanup.h"
+#include "../Source/audio/modulation/LfoParameters.h"
 #include "../Source/audio/modulation/LfoState.h"
 
 // ============================================================================
@@ -683,6 +685,43 @@ public:
 };
 
 // ============================================================================
+// Test 8: Preview assignments restore the exact pre-preview state
+// ============================================================================
+
+class LfoPreviewAssignmentTest : public juce::UnitTest {
+public:
+    LfoPreviewAssignmentTest() : juce::UnitTest("LFO Preview Assignment Restoration", "LFO") {}
+
+    void runTest() override {
+        beginTest("Stopping preview preserves existing assignments");
+
+        LfoParameters lfoParameters;
+        osci::EffectParameter parameter("Amount", "", "previewAmount", 2, 0.75f, 0.0f, 1.0f, 0.01f,
+                                        osci::LfoType::Sine, 2.0f);
+        auto effect = std::make_shared<osci::SimpleEffect>(&parameter);
+        std::vector<std::shared_ptr<osci::Effect>> effects{effect};
+        const LfoAssignment original{7, parameter.paramID, 0.35f, true};
+        lfoParameters.addAssignment(original);
+
+        lfoParameters.startPreview(effect->getId(), effects);
+        lfoParameters.stopPreview();
+
+        const auto restored = lfoParameters.getAssignments();
+        expectEquals(static_cast<int>(restored.size()), 1);
+        if (restored.size() == 1) {
+            expectEquals(restored[0].sourceIndex, original.sourceIndex);
+            expectEquals(restored[0].paramId, original.paramId);
+            expectWithinAbsoluteError(restored[0].depth, original.depth, 0.0001f);
+            expect(restored[0].bipolar == original.bipolar);
+        }
+        expectWithinAbsoluteError(parameter.getValueUnnormalised(), 0.75f, 0.0001f);
+
+        testutil::cleanupSubParams(parameter);
+        testutil::cleanupLfoParams(lfoParameters);
+    }
+};
+
+// ============================================================================
 // Static registration — JUCE auto-discovers these
 // ============================================================================
 static LfoAssignmentRaceTest lfoAssignmentRaceTest;
@@ -692,3 +731,4 @@ static LfoAssignmentOrderTest lfoAssignmentOrderTest;
 static LfoFullSystemStressTest lfoFullSystemStressTest;
 static LfoWaveformCorrectnessTest lfoWaveformCorrectnessTest;
 static LfoSerializationTest lfoSerializationTest;
+static LfoPreviewAssignmentTest lfoPreviewAssignmentTest;


### PR DESCRIPTION
## Summary

- restore the constant synth note correctly when MIDI is disabled at startup
- avoid effect-grid hover processing entirely when hover preview is disabled
- make temporary LFO preview assignment and restoration lightweight
- preserve assignments that existed before a temporary preview
- clear active effect and LFO previews when hover preview is disabled
- preserve an effect preview's local DSP state when the effect is enabled
- enable previewed effects atomically so the audio thread cannot observe partial state
- avoid redundant effect-list rebuilding and broad processor notifications when enabling an effect
- simplify preview assignment removal and preview-mode handling

## Root cause

Effect hover entered unnecessary cleanup paths even when previewing was disabled. With previewing enabled, temporary LFO setup copied all LFO waveforms, sent broad UI notifications, and used persistent parameter notifications for transient hover state. This caused avoidable message-thread work and project-state churn while moving across the effect grid.

Enabling a previewed effect also repeated setup work and exposed intermediate selected/enabled state to the audio thread. At very small audio buffer sizes, that message-thread and audio-thread work could produce an audible stutter. The final path reuses the already prepared preview effect, preserves its local DSP state, applies its final state under the existing effects lock, and avoids a redundant full UI refresh.

The MIDI-disabled startup path could also leave the synthetic constant note inactive while synth voices were still being prepared.

## Validation

- `./run_tests.sh --category LFO`
- focused LFO preview assignment/restoration and stress coverage
- macOS JUCE 9 Debug standalone build
- manual verification of effect hover, preview-to-enable continuity, and low-buffer effect enabling
- `git -c core.whitespace=cr-at-eol diff --check`
- independent code review

The standalone Debug build was opened for manual audio and UI verification. Jucewright was not run.

