### PR TITLE
Improve visualiser settings and workflow controls

### DIFF
--- a/Resources/svg/push_pin.svg
+++ b/Resources/svg/push_pin.svg
@@ -1,3 +1,0 @@
-<!-- Google Material Symbols "push_pin" (outlined), Apache License 2.0.
-     Source: https://github.com/google/material-design-icons/blob/master/symbols/web/push_pin/materialsymbolsoutlined/push_pin_24px.svg -->
-<svg xmlns="http://www.w3.org/2000/svg" height="24" width="24" viewBox="0 0 24 24"><path d="m16 12 2 2v2h-5v6l-1 1-1-1v-6H6v-2l2-2V5H7V3h10v2h-1Zm-7.15 2h6.3L14 12.85V5h-4v7.85ZM12 14Z"/></svg>

--- a/Resources/svg/push_pin.svg
+++ b/Resources/svg/push_pin.svg
@@ -1,0 +1,3 @@
+<!-- Google Material Symbols "push_pin" (outlined), Apache License 2.0.
+     Source: https://github.com/google/material-design-icons/blob/master/symbols/web/push_pin/materialsymbolsoutlined/push_pin_24px.svg -->
+<svg xmlns="http://www.w3.org/2000/svg" height="24" width="24" viewBox="0 0 24 24"><path d="m16 12 2 2v2h-5v6l-1 1-1-1v-6H6v-2l2-2V5H7V3h10v2h-1Zm-7.15 2h6.3L14 12.85V5h-4v7.85ZM12 14Z"/></svg>

--- a/Source/CommonPluginEditor.cpp
+++ b/Source/CommonPluginEditor.cpp
@@ -84,7 +84,7 @@ CommonPluginEditor::CommonPluginEditor(CommonAudioProcessor& p, juce::String app
     int height = std::any_cast<int>(audioProcessor.getProperty("appHeight", defaultHeight));
 
     visualiserSettings.setLookAndFeel(&getLookAndFeel());
-    visualiserSettings.setSize(550, VISUALISER_SETTINGS_HEIGHT);
+    visualiserSettings.setSizeToFitWidth(550);
     visualiserSettings.setColour(juce::ResizableWindow::backgroundColourId, osci::Colours::dark());
 
     recordingSettings.setLookAndFeel(&getLookAndFeel());
@@ -96,7 +96,7 @@ CommonPluginEditor::CommonPluginEditor(CommonAudioProcessor& p, juce::String app
     setResizable(true, true);
     setResizeLimits(250, 250, 999999, 999999);
 
-    tooltipWindow->setMillisecondsBeforeTipAppears(100);
+    tooltipWindow->setMillisecondsBeforeTipAppears(500);
 
     updateTitle();
 

--- a/Source/CommonPluginEditor.cpp
+++ b/Source/CommonPluginEditor.cpp
@@ -18,7 +18,7 @@ const auto& offlineRenderLog = osci::WorkflowLoggers::offlineAudioToVideo;
 }
 
 CommonPluginEditor::CommonPluginEditor(CommonAudioProcessor& p, juce::String appName, juce::String projectFileType, int defaultWidth, int defaultHeight)
-    : AudioProcessorEditor(&p), audioProcessor(p), appName(appName), projectFileType(projectFileType)
+    : AudioProcessorEditor(&p), audioProcessor(p), defaultEditorWidth(defaultWidth), defaultEditorHeight(defaultHeight), appName(appName), projectFileType(projectFileType)
 {
 #if JUCE_LINUX
     // use OpenGL on Linux for much better performance. The default on Mac is CoreGraphics, and on Window is Direct2D which is much faster.
@@ -320,6 +320,18 @@ bool CommonPluginEditor::handleShortcut(const juce::KeyPress& key) {
     } else if (key.getModifiers().isCommandDown() && key.getKeyCode() == 'O') {
         openProject();
         return true;
+    } else if (key.getModifiers().isCommandDown() && key.getKeyCode() == 'N' && juce::JUCEApplicationBase::isStandaloneApp()) {
+        resetToDefault();
+        return true;
+    } else if (key.getModifiers().isCommandDown() && key.getModifiers().isShiftDown() && key.getKeyCode() == 'M') {
+        audioProcessor.muteParameter->setBoolValueNotifyingHost(!audioProcessor.muteParameter->getBoolValue());
+        return true;
+    } else if (key.isKeyCode(juce::KeyPress::F11Key) && juce::JUCEApplicationBase::isStandaloneApp()) {
+        toggleFullScreen();
+        return true;
+    } else if (key.isKeyCode(juce::KeyPress::escapeKey) && isFullScreen()) {
+        toggleFullScreen();
+        return true;
     }
     return false;
 }
@@ -332,18 +344,6 @@ bool CommonPluginEditor::keyPressed(const juce::KeyPress& key) {
     // Other special keys gated by user preference
     if (!audioProcessor.getAcceptsKeys()) return false;
 
-    if (key.isKeyCode(juce::KeyPress::F11Key) && juce::JUCEApplicationBase::isStandaloneApp()) {
-#if OSCI_PREMIUM
-        toggleFullScreen();
-        return true;
-#endif
-    } else if (key.isKeyCode(juce::KeyPress::escapeKey) && juce::JUCEApplicationBase::isStandaloneApp()) {
-        if (fullScreen) {
-            toggleFullScreen();
-            return true;
-        }
-    }
-
     return false;
 }
 
@@ -355,9 +355,11 @@ bool CommonPluginEditor::keyPressed(const juce::KeyPress& key, juce::Component*)
 void CommonPluginEditor::openProject(const juce::File& file) {
     if (file != juce::File()) {
         auto data = juce::MemoryBlock();
-        if (file.loadFileAsData(data)) {
-            audioProcessor.setStateInformation(data.getData(), data.getSize());
+        if (!file.loadFileAsData(data)) {
+            osci::showOverlayMessage(*this, "Open Project Failed", "Could not read:\n" + file.getFullPathName());
+            return;
         }
+        audioProcessor.setStateInformation(data.getData(), data.getSize());
         audioProcessor.currentProjectFile = file.getFullPathName();
         audioProcessor.setLastOpenedDirectory(file.getParentDirectory());
         audioProcessor.addRecentProjectFile(file);
@@ -384,8 +386,10 @@ void CommonPluginEditor::saveProject() {
         auto data = juce::MemoryBlock();
         audioProcessor.getStateInformation(data);
         auto file = juce::File(audioProcessor.currentProjectFile);
-        file.create();
-        file.replaceWithData(data.getData(), data.getSize());
+        if (!file.replaceWithData(data.getData(), data.getSize())) {
+            osci::showOverlayMessage(*this, "Save Project Failed", "Could not write:\n" + file.getFullPathName());
+            return;
+        }
         updateTitle();
     }
 }
@@ -401,12 +405,28 @@ void CommonPluginEditor::saveProjectAs() {
 
         auto file = chooser.getResult();
         if (file != juce::File()) {
+            if (!file.hasFileExtension(safeThis->projectFileType)) {
+                file = file.withFileExtension(safeThis->projectFileType);
+            }
             safeThis->audioProcessor.setLastOpenedDirectory(file.getParentDirectory());
             safeThis->audioProcessor.currentProjectFile = file.getFullPathName();
             safeThis->audioProcessor.addRecentProjectFile(file);
             safeThis->saveProject();
         }
     });
+}
+
+void CommonPluginEditor::resetWindowSizeAndPosition() {
+    auto* standaloneWindow = findParentComponentOfClass<juce::StandaloneFilterWindow>();
+    if (standaloneWindow != nullptr) {
+        standaloneWindow->setFullScreen(false);
+    }
+    fullScreen = false;
+    setSize(defaultEditorWidth, defaultEditorHeight);
+    auto* window = getTopLevelComponent();
+    if (window != nullptr && window != this) {
+        window->centreWithSize(window->getWidth(), window->getHeight());
+    }
 }
 
 void CommonPluginEditor::updateTitle() {
@@ -589,7 +609,7 @@ void CommonPluginEditor::renderAudioFileToVideo() {
 
             content->setSize(700, 520);
 
-            content->setOnFinished([safeThis, resultHolder, overlayHolder](OfflineAudioToVideoRendererComponent::Result r) {
+            content->setOnFinished([safeThis, resultHolder, overlayHolder, outputFile](OfflineAudioToVideoRendererComponent::Result r) {
                 if (safeThis == nullptr) {
                     offlineRenderLog.cancelled("result delivery because editor closed");
                     return;
@@ -599,6 +619,7 @@ void CommonPluginEditor::renderAudioFileToVideo() {
 
                 if (r.success) {
                     offlineRenderLog.completed();
+                    safeThis->audioProcessor.recordingExportCompleted(outputFile);
                 } else if (r.cancelled) {
                     offlineRenderLog.cancelled("render");
                 } else {
@@ -653,7 +674,7 @@ void CommonPluginEditor::toggleFullScreen() {
 #if JUCE_WINDOWS
     juce::StandaloneFilterWindow* window = findParentComponentOfClass<juce::StandaloneFilterWindow>();
     if (window != nullptr) {
-        fullScreen = !fullScreen;
+        fullScreen = !window->isFullScreen();
 
         if (fullScreen) {
             // Store the current window bounds before going fullscreen
@@ -679,8 +700,13 @@ void CommonPluginEditor::toggleFullScreen() {
 #else
     juce::StandaloneFilterWindow* window = findParentComponentOfClass<juce::StandaloneFilterWindow>();
     if (window != nullptr) {
-        fullScreen = !fullScreen;
+        fullScreen = !window->isFullScreen();
         window->setFullScreen(fullScreen);
     }
 #endif
+}
+
+bool CommonPluginEditor::isFullScreen() {
+    auto* window = findParentComponentOfClass<juce::StandaloneFilterWindow>();
+    return window != nullptr && window->isFullScreen();
 }

--- a/Source/CommonPluginEditor.h
+++ b/Source/CommonPluginEditor.h
@@ -71,12 +71,6 @@ public:
     DownloaderComponent ffmpegDownloader;
 #endif
 
-#if OSCI_PREMIUM
-    int VISUALISER_SETTINGS_HEIGHT = 1300;
-#else
-    int VISUALISER_SETTINGS_HEIGHT = 770;
-#endif
-
     VisualiserSettings visualiserSettings = VisualiserSettings(audioProcessor.visualiserParameters, 3, audioProcessor.recordingParameters);
     RecordingSettings recordingSettings = RecordingSettings(audioProcessor.recordingParameters);
     VisualiserComponent visualiser{

--- a/Source/CommonPluginEditor.h
+++ b/Source/CommonPluginEditor.h
@@ -27,6 +27,7 @@ public:
     virtual void openProject();
     void saveProject();
     void saveProjectAs();
+    virtual void resetWindowSizeAndPosition();
     void updateTitle();
     void fileUpdated(juce::String fileName);
     void openAudioSettings();
@@ -53,11 +54,14 @@ public:
     void renderAudioFileToVideo();
     virtual void resetToDefault();
     void toggleFullScreen();
+    bool isFullScreen();
     void resized() override;
     void parentHierarchyChanged() override;
 
 private:
     CommonAudioProcessor& audioProcessor;
+    int defaultEditorWidth = 0;
+    int defaultEditorHeight = 0;
     bool fullScreen = false;
     juce::Rectangle<int> windowedBounds;
 public:

--- a/Source/CommonPluginProcessor.cpp
+++ b/Source/CommonPluginProcessor.cpp
@@ -102,6 +102,14 @@ CommonAudioProcessor::CommonAudioProcessor(const BusesProperties& busesPropertie
             recentProjectFiles.restoreFromString(savedRecent);
     }
 
+    recentRecordingFiles.setMaxNumberOfItems(10);
+    {
+        const auto savedRecordings = globalSettings.getString("recentRecordingFiles");
+        if (savedRecordings.isNotEmpty()) {
+            recentRecordingFiles.restoreFromString(savedRecordings);
+        }
+    }
+
     // locking isn't necessary here because we are in the constructor
 
     for (auto effect : visualiserParameters.effects) {
@@ -197,6 +205,41 @@ int CommonAudioProcessor::createRecentProjectsPopupMenuItems(juce::PopupMenu& me
                                                    showFullPaths,
                                                    dontAddNonExistentFiles,
                                                    nullptr);
+}
+
+void CommonAudioProcessor::clearRecentProjectFiles() {
+    recentProjectFiles.clear();
+    globalSettings.set("recentProjectFiles", juce::String());
+    globalSettings.save();
+}
+
+void CommonAudioProcessor::recordingExportCompleted(const juce::File& file) {
+    if (file == juce::File()) {
+        return;
+    }
+
+    recentRecordingFiles.addFile(file);
+    globalSettings.set("recentRecordingFiles", recentRecordingFiles.toString());
+    globalSettings.save();
+    if (globalSettings.getBool("showVideoAfterExport", false)) {
+        file.revealToUser();
+    }
+}
+
+juce::File CommonAudioProcessor::getRecentRecordingFile(int index) const {
+    return recentRecordingFiles.getFile(index);
+}
+
+int CommonAudioProcessor::createRecentRecordingsPopupMenuItems(juce::PopupMenu& menuToAddItemsTo, int baseItemId) {
+    const auto before = recentRecordingFiles.toString();
+    recentRecordingFiles.removeNonExistentFiles();
+    const auto after = recentRecordingFiles.toString();
+    if (after != before) {
+        globalSettings.set("recentRecordingFiles", after);
+        globalSettings.save();
+    }
+
+    return recentRecordingFiles.createPopupMenuItems(menuToAddItemsTo, baseItemId, false, true, nullptr);
 }
 
 void CommonAudioProcessor::saveStandaloneProjectFilePathToXml(juce::XmlElement& xml) const

--- a/Source/CommonPluginProcessor.h
+++ b/Source/CommonPluginProcessor.h
@@ -37,6 +37,10 @@ public:
     juce::UndoManager& getUndoManager() { return undoManager; }
     juce::String getProductSlug() const;
     void getPortableProjectSnapshot(juce::MemoryBlock& destData);
+    void clearRecentProjectFiles();
+    void recordingExportCompleted(const juce::File& file);
+    juce::File getRecentRecordingFile(int index) const;
+    int createRecentRecordingsPopupMenuItems(juce::PopupMenu& menuToAddItemsTo, int baseItemId);
 
     void prepareToPlay (double sampleRate, int samplesPerBlock) override final;
     void releaseResources() override;
@@ -265,6 +269,7 @@ protected:
     std::unique_ptr<juce::FileLogger> fileLogger;
 
     juce::RecentlyOpenedFilesList recentProjectFiles;
+    juce::RecentlyOpenedFilesList recentRecordingFiles;
 
     //==============================================================================
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (CommonAudioProcessor)

--- a/Source/PluginEditor.cpp
+++ b/Source/PluginEditor.cpp
@@ -765,6 +765,24 @@ void OscirenderAudioProcessorEditor::toggleLayout(juce::StretchableLayoutManager
     }
 }
 
+void OscirenderAudioProcessorEditor::resetWindowSizeAndPosition() {
+    CommonPluginEditor::resetWindowSizeAndPosition();
+
+    layout.setItemLayout(0, -0.3, -1.0, kDefaultCodeEditorMainPanelSize);
+    layout.setItemLayout(1, RESIZER_BAR_SIZE, RESIZER_BAR_SIZE, RESIZER_BAR_SIZE);
+    layout.setItemLayout(2, -0.0, -1.0, -(1.0 + kDefaultCodeEditorMainPanelSize));
+
+    constexpr double defaultLuaLayoutSize = -0.7;
+    luaLayout.setItemLayout(0, -0.3, -1.0, defaultLuaLayoutSize);
+    luaLayout.setItemLayout(1, RESIZER_BAR_SIZE, RESIZER_BAR_SIZE, RESIZER_BAR_SIZE);
+    luaLayout.setItemLayout(2, -0.1, -1.0, -(1.0 + defaultLuaLayoutSize));
+
+    audioProcessor.setProperty("codeEditorLayoutPreferredSize", kDefaultCodeEditorMainPanelSize);
+    audioProcessor.setProperty("luaLayoutPreferredSize", defaultLuaLayoutSize);
+    settings.resetLayoutToDefault();
+    resized();
+}
+
 void OscirenderAudioProcessorEditor::editCustomFunction(bool enable) {
     if (enable) {
         // Record whether the code editor was open before entering custom-function edit mode.

--- a/Source/PluginEditor.h
+++ b/Source/PluginEditor.h
@@ -85,7 +85,7 @@ public:
     LuaComponent lua{audioProcessor, *this};
     TxtComponent txtFont{audioProcessor, *this};
 
-    SettingsWindow visualiserSettingsWindow = SettingsWindow("Visualiser Settings", visualiserSettings, 550, 500, 1500, VISUALISER_SETTINGS_HEIGHT);
+    SettingsWindow visualiserSettingsWindow = SettingsWindow("Visualiser Settings", visualiserSettings, 550, 500, 1500);
 
     osci::LuaConsoleComponent console;
 

--- a/Source/PluginEditor.h
+++ b/Source/PluginEditor.h
@@ -38,6 +38,7 @@ public:
     void openProject(const juce::File& file) override;
     void openProject() override;
     void resetToDefault() override;
+    void resetWindowSizeAndPosition() override;
     void setTextureInputSource(osci::texture::SourceInfo source);
     void stopTextureInput();
     bool isTextureInputActive() const;

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -136,6 +136,9 @@ OscirenderAudioProcessor::OscirenderAudioProcessor()
     booleanParameters.push_back(loopAnimation);
     booleanParameters.push_back(animationSyncBPM);
     booleanParameters.push_back(invertImage);
+    booleanParameters.push_back(swapXYOutput);
+    booleanParameters.push_back(invertXOutput);
+    booleanParameters.push_back(invertYOutput);
 
     // Adopt envelope parameters
     for (auto* p : envelopeParameters.getFloatParameters())
@@ -192,6 +195,7 @@ OscirenderAudioProcessor::OscirenderAudioProcessor()
 
     intParameters.push_back(voices);
     intParameters.push_back(fileSelect);
+    intParameters.push_back(midiInputChannel);
 #if OSCI_PREMIUM
     intParameters.push_back(pitchBendRange);
 #endif
@@ -220,6 +224,7 @@ OscirenderAudioProcessor::OscirenderAudioProcessor()
 #endif
     voiceBuilder->setTargetVoiceCount(initialVoices + 1); // +1 overlap voice for kill-fade
     voiceBuilder->startThread(juce::Thread::Priority::low);
+    filteredMidiMessages.ensureSize(65536);
 
     for (int i = 0; i < luaEffects.size(); i++) {
         luaEffects[i]->parameters[0]->addListener(this);
@@ -595,9 +600,6 @@ void OscirenderAudioProcessor::processBlockInternal(juce::AudioBuffer<float>& bu
     // Calculated time per sample in seconds.
     double sTimeSec = blockDawPosition.secondsPerSample.load(std::memory_order_relaxed);
 
-    // merge keyboard state and midi messages
-    keyboardState.processNextMidiBuffer(midiMessages, 0, buffer.getNumSamples(), true);
-
     fileController.updatePendingSelectionFromParameter();
 
     // Process MIDI mappings and handlers (always active, even when synth MIDI is off).
@@ -607,6 +609,23 @@ void OscirenderAudioProcessor::processBlockInternal(juce::AudioBuffer<float>& bu
     // Parse MTS SysEx from incoming MIDI for microtuning support
     mtsClient.parseMidiBuffer(midiMessages);
 #endif
+
+    const int selectedMidiChannel = midiInputChannel->getValueUnnormalised();
+    if (selectedMidiChannel != 0) {
+        filteredMidiMessages.clear();
+        for (const auto metadata : midiMessages) {
+            const auto message = metadata.getMessage();
+            if (message.getChannel() == 0 || message.getChannel() == selectedMidiChannel) {
+                filteredMidiMessages.addEvent(message, metadata.samplePosition);
+            }
+        }
+        midiMessages.clear();
+        midiMessages.addEvents(filteredMidiMessages, 0, -1, 0);
+    }
+
+    // The on-screen keyboard remains usable regardless of the external MIDI
+    // channel filter.
+    keyboardState.processNextMidiBuffer(midiMessages, 0, buffer.getNumSamples(), true);
 
     bool usingInput = inputEnabled->getBoolValue();
 
@@ -868,12 +887,18 @@ void OscirenderAudioProcessor::processBlockInternal(juce::AudioBuffer<float>& bu
         juce::FloatVectorOperations::clear(outputArray[1], numSamples);
     }
     
-    // Copy to output channels
+    // Apply hardware routing after publishing the visualiser feed so these
+    // corrections affect physical outputs and recordings, not the preview.
+    const bool swapOutput = swapXYOutput->getBoolValue();
+    const int xSource = swapOutput ? 1 : 0;
+    const int ySource = swapOutput ? 0 : 1;
+    const float xGain = invertXOutput->getBoolValue() ? -1.0f : 1.0f;
+    const float yGain = invertYOutput->getBoolValue() ? -1.0f : 1.0f;
     if (totalNumOutputChannels >= 2) {
-        juce::FloatVectorOperations::copy(channelData[0], outputArray[0], numSamples);
-        juce::FloatVectorOperations::copy(channelData[1], outputArray[1], numSamples);
+        juce::FloatVectorOperations::copyWithMultiply(channelData[0], outputArray[xSource], xGain, numSamples);
+        juce::FloatVectorOperations::copyWithMultiply(channelData[1], outputArray[ySource], yGain, numSamples);
     } else if (totalNumOutputChannels == 1) {
-        juce::FloatVectorOperations::copy(channelData[0], outputArray[0], numSamples);
+        juce::FloatVectorOperations::copyWithMultiply(channelData[0], outputArray[xSource], xGain, numSamples);
     }
     
     // used for any callback that must guarantee all audio is recieved (e.g. when recording to a file)
@@ -881,6 +906,12 @@ void OscirenderAudioProcessor::processBlockInternal(juce::AudioBuffer<float>& bu
     if (audioThreadCallback != nullptr) {
         audioThreadCallback(buffer);
     }
+}
+
+void OscirenderAudioProcessor::sendMidiPanic(bool immediate) {
+    keyboardState.allNotesOff(0);
+    synth.handleMidiEvent(immediate ? juce::MidiMessage::allSoundOff(1)
+                                    : juce::MidiMessage::allNotesOff(1));
 }
 
 juce::AudioProcessorEditor* OscirenderAudioProcessor::createEditor() {

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -622,6 +622,12 @@ void OscirenderAudioProcessor::processBlockInternal(juce::AudioBuffer<float>& bu
         midiMessages.clear();
         midiMessages.addEvents(filteredMidiMessages, 0, -1, 0);
     }
+    if (selectedMidiChannel != previousMidiInputChannel) {
+        // VoiceManager treats allSoundOff globally, so one message releases
+        // notes that would otherwise be hidden by the new channel filter.
+        midiMessages.addEvent(juce::MidiMessage::allSoundOff(1), 0);
+        previousMidiInputChannel = selectedMidiChannel;
+    }
 
     // The on-screen keyboard remains usable regardless of the external MIDI
     // channel filter.

--- a/Source/PluginProcessor.h
+++ b/Source/PluginProcessor.h
@@ -343,6 +343,7 @@ private:
     juce::AudioBuffer<float> inputFrequencyBuffer;
     juce::AudioBuffer<float> outputBuffer3d;
     juce::MidiBuffer filteredMidiMessages;
+    int previousMidiInputChannel = 0;
 
     std::atomic<bool> prevMidiEnabled = !midiEnabled->getBoolValue();
 

--- a/Source/PluginProcessor.h
+++ b/Source/PluginProcessor.h
@@ -39,6 +39,21 @@
 #include <osci_file_import/osci_file_import.h>
 #include <osci_scripting/osci_scripting.h>
 
+class MidiInputChannelParameter : public osci::IntParameter {
+public:
+    MidiInputChannelParameter() : osci::IntParameter("MIDI Input Channel", "midiInputChannel", VERSION_HINT, 0, 0, 16) {}
+
+    juce::String getText(float value, int maximumStringLength) const override {
+        const int channel = (int)getUnnormalisedValue(value);
+        const juce::String text = channel == 0 ? "Omni" : "Channel " + juce::String(channel);
+        return text.substring(0, maximumStringLength);
+    }
+
+    float getValueForText(const juce::String& text) const override {
+        return getNormalisedValue(text.equalsIgnoreCase("Omni") ? 0 : text.getTrailingIntValue());
+    }
+};
+
 //==============================================================================
 
 // Central 60 Hz timer that drives modulation display updates (LFO overlays,
@@ -214,6 +229,7 @@ public:
     juce::MidiKeyboardState keyboardState;
 
     osci::IntParameter* voices = new osci::IntParameter("Voices", "voices", VERSION_HINT, 4, 1, 16);
+    MidiInputChannelParameter* midiInputChannel = new MidiInputChannelParameter();
 
     // 1..100 maps to file index with a 1-based offset (1 = first file, 2 = second, ...). Intended for DAW automation.
     osci::IntParameter* fileSelect = new osci::IntParameter("File Select", "fileSelect", VERSION_HINT, 1, 1, 100);
@@ -233,6 +249,7 @@ public:
 
     // Number of MIDI notes currently held. Audio-thread only.
     int getNumPressedNotes() const;
+    void sendMidiPanic(bool immediate);
 
     // Frequency of the globally-last-played note (before the current noteOn).
     // Used as glide source so any voice can portamento from the last note.
@@ -252,6 +269,9 @@ public:
     osci::FloatParameter* animationOffset = new osci::FloatParameter("Animation Offset", "animationOffset", VERSION_HINT, 0, -10000, 10000);
 
     osci::BooleanParameter* invertImage = new osci::BooleanParameter("Invert Image", "invertImage", VERSION_HINT, false, "Inverts the image so that dark pixels become light, and vice versa.");
+    osci::BooleanParameter* swapXYOutput = new osci::BooleanParameter("Swap X/Y Output", "swapXYOutput", VERSION_HINT, false, "Swaps the physical X and Y audio output channels.");
+    osci::BooleanParameter* invertXOutput = new osci::BooleanParameter("Invert X Output", "invertXOutput", VERSION_HINT, false, "Inverts the polarity of the physical X audio output.");
+    osci::BooleanParameter* invertYOutput = new osci::BooleanParameter("Invert Y Output", "invertYOutput", VERSION_HINT, false, "Inverts the polarity of the physical Y audio output.");
     std::shared_ptr<osci::Effect> imageThreshold = std::make_shared<osci::SimpleEffect>(
         new osci::EffectParameter(
             "Image Threshold",
@@ -322,6 +342,7 @@ private:
     juce::AudioBuffer<float> inputBuffer;
     juce::AudioBuffer<float> inputFrequencyBuffer;
     juce::AudioBuffer<float> outputBuffer3d;
+    juce::MidiBuffer filteredMidiMessages;
 
     std::atomic<bool> prevMidiEnabled = !midiEnabled->getBoolValue();
 

--- a/Source/SosciPluginEditor.cpp
+++ b/Source/SosciPluginEditor.cpp
@@ -80,7 +80,6 @@ void SosciPluginEditor::resized() {
         }
 
         auto settingsArea = area.removeFromRight(juce::jmax(juce::jmin(0.4 * getWidth(), 550.0), 350.0));
-        visualiserSettings.setSize(settingsArea.getWidth(), VISUALISER_SETTINGS_HEIGHT);
         visualiserSettingsWrapper.setBounds(settingsArea);
 
         if (area.getWidth() < 10) {

--- a/Source/SosciPluginProcessor.cpp
+++ b/Source/SosciPluginProcessor.cpp
@@ -148,13 +148,15 @@ void SosciAudioProcessor::processBlockInternal(juce::AudioBuffer<float>& buffer,
 
     if (juce::JUCEApplication::isStandaloneApp()) {
         applyVolumeAndThreshold(workArray, numSamples);
+    }
 
-        // apply mute if active
-        if (muteParameter->getBoolValue()) {
-            juce::FloatVectorOperations::clear(workArray[0], numSamples);
-            juce::FloatVectorOperations::clear(workArray[1], numSamples);
-        }
+    // Mute the physical output in both standalone and plugin wrappers.
+    if (muteParameter->getBoolValue()) {
+        juce::FloatVectorOperations::clear(workArray[0], numSamples);
+        juce::FloatVectorOperations::clear(workArray[1], numSamples);
+    }
 
+    if (juce::JUCEApplication::isStandaloneApp()) {
         threadManager.write(workBuffer, "VolumeComponent");
     }
 

--- a/Source/components/effects/EffectComponent.cpp
+++ b/Source/components/effects/EffectComponent.cpp
@@ -110,6 +110,7 @@ void EffectComponent::setupComponent() {
     }
 
     setTooltip(parameter->description);
+    label.setTooltip(parameter->description);
     label.setText(parameter->name, juce::dontSendNotification);
     label.onContextMenu = [this](juce::Point<int> screenPosition) {
         showContextMenu(screenPosition);

--- a/Source/components/menu/MainMenuBarModel.cpp
+++ b/Source/components/menu/MainMenuBarModel.cpp
@@ -17,8 +17,15 @@ void MainMenuBarModel::addMenuItem(int topLevelMenuIndex, const juce::String& na
     menuItemsChanged();
 }
 
-void MainMenuBarModel::addToggleMenuItem(int topLevelMenuIndex, const juce::String& name, std::function<void()> action, std::function<bool()> isTicked) {
-    menuItems[topLevelMenuIndex].push_back({ name, std::move(action), std::move(isTicked), true });
+void MainMenuBarModel::addMenuSeparator(int topLevelMenuIndex) {
+    MenuItem separator;
+    separator.isSeparator = true;
+    menuItems[topLevelMenuIndex].push_back(std::move(separator));
+    menuItemsChanged();
+}
+
+void MainMenuBarModel::addToggleMenuItem(int topLevelMenuIndex, const juce::String& name, std::function<void()> action, std::function<bool()> isTicked, const juce::String& shortcutKey) {
+    menuItems[topLevelMenuIndex].push_back({ name, std::move(action), std::move(isTicked), true, shortcutKey });
     menuItemsChanged();
 }
 
@@ -38,8 +45,8 @@ void MainMenuBarModel::addDiagnosticsMenuItems(int topLevelMenuIndex, CommonAudi
 
 void MainMenuBarModel::addEditMenuItems(int topLevelMenuIndex, CommonAudioProcessor& processor) {
    #if JUCE_MAC
-    const juce::String undoShortcut = juce::String::fromUTF8("\xe2\x8c\x98Z");       // ⌘Z
-    const juce::String redoShortcut = juce::String::fromUTF8("\xe2\x87\xa7\xe2\x8c\x98Z"); // ⇧⌘Z
+    const juce::String undoShortcut = "Cmd+Z";
+    const juce::String redoShortcut = "Cmd+Shift+Z";
    #else
     const juce::String undoShortcut = "Ctrl+Z";
     const juce::String redoShortcut = "Ctrl+Shift+Z";
@@ -67,6 +74,10 @@ juce::PopupMenu MainMenuBarModel::getMenuForIndex(int topLevelMenuIndex, const j
 
     for (int i = 0; i < (int) menuItems[topLevelMenuIndex].size(); i++) {
         auto& mi = menuItems[topLevelMenuIndex][i];
+        if (mi.isSeparator) {
+            menu.addSeparator();
+            continue;
+        }
         juce::PopupMenu::Item item(mi.name);
         item.itemID = i + 1;
         if (mi.shortcutKey.isNotEmpty())

--- a/Source/components/menu/MainMenuBarModel.cpp
+++ b/Source/components/menu/MainMenuBarModel.cpp
@@ -1,5 +1,6 @@
 #include "MainMenuBarModel.h"
 
+#include "../../CommonPluginEditor.h"
 #include "../../CommonPluginProcessor.h"
 
 MainMenuBarModel::MainMenuBarModel() {}
@@ -10,6 +11,15 @@ void MainMenuBarModel::addTopLevelMenu(const juce::String& name) {
     topLevelMenuNames.add(name);
     menuItems.push_back({});
     menuItemsChanged();
+}
+
+void MainMenuBarModel::addStandardTopLevelMenus() {
+    addTopLevelMenu("File");
+    addTopLevelMenu("Edit");
+    addTopLevelMenu("About");
+    addTopLevelMenu("Video");
+    addTopLevelMenu("Audio");
+    addTopLevelMenu("Interface");
 }
 
 void MainMenuBarModel::addMenuItem(int topLevelMenuIndex, const juce::String& name, std::function<void()> action, const juce::String& shortcutKey) {
@@ -43,6 +53,12 @@ void MainMenuBarModel::addDiagnosticsMenuItems(int topLevelMenuIndex, CommonAudi
     });
 }
 
+void MainMenuBarModel::addSupportMenuItems(int topLevelMenuIndex, CommonAudioProcessor& processor, CommonPluginEditor& editor) {
+    addMenuItem(topLevelMenuIndex, "License and Updates...", [&editor] { editor.openLicenseAndUpdates(); });
+    addMenuItem(topLevelMenuIndex, "Send Feedback...", [&editor] { editor.openFeedback(); });
+    addDiagnosticsMenuItems(topLevelMenuIndex, processor);
+}
+
 void MainMenuBarModel::addEditMenuItems(int topLevelMenuIndex, CommonAudioProcessor& processor) {
    #if JUCE_MAC
     const juce::String undoShortcut = "Cmd+Z";
@@ -59,6 +75,99 @@ void MainMenuBarModel::addListenForSpecialKeysMenuItem(int topLevelMenuIndex, Co
     addToggleMenuItem(topLevelMenuIndex, "Listen for Special Keys", [this, &processor] {
         processor.setAcceptsKeys(! processor.getAcceptsKeys());
     }, [&processor] { return processor.getAcceptsKeys(); });
+}
+
+void MainMenuBarModel::addProjectMenuItems(int topLevelMenuIndex, CommonAudioProcessor& processor, CommonPluginEditor& editor) {
+    addMenuItem(topLevelMenuIndex, "Open Project", [&editor] { editor.openProject(); }, JUCE_MAC ? "Cmd+O" : "Ctrl+O");
+    addMenuItem(topLevelMenuIndex, "Save Project", [&editor] { editor.saveProject(); }, JUCE_MAC ? "Cmd+S" : "Ctrl+S");
+    addMenuItem(topLevelMenuIndex, "Save Project As", [&editor] { editor.saveProjectAs(); }, JUCE_MAC ? "Cmd+Shift+S" : "Ctrl+Shift+S");
+    if (processor.wrapperType == juce::AudioProcessor::WrapperType::wrapperType_Standalone) {
+        addMenuItem(topLevelMenuIndex, "Create New Project", [&editor] { editor.resetToDefault(); }, JUCE_MAC ? "Cmd+N" : "Ctrl+N");
+    }
+}
+
+void MainMenuBarModel::addRecentProjectsSubmenu(juce::PopupMenu& menu, CommonAudioProcessor& processor, int recentBaseId, int clearRecentId) {
+    juce::PopupMenu recentMenu;
+    const int added = processor.createRecentProjectsPopupMenuItems(recentMenu, recentBaseId, true, true);
+    if (added == 0) {
+        recentMenu.addItem(recentBaseId, "(No Recent Projects)", false);
+    }
+    recentMenu.addSeparator();
+    recentMenu.addItem(clearRecentId, "Clear Recent Projects", added > 0);
+    menu.addSubMenu("Open Recent", recentMenu);
+}
+
+bool MainMenuBarModel::handleRecentProjectMenuItem(int menuItemId, CommonAudioProcessor& processor, CommonPluginEditor& editor, int recentBaseId, int clearRecentId) {
+    if (menuItemId == clearRecentId) {
+        processor.clearRecentProjectFiles();
+        return true;
+    }
+    if (menuItemId < recentBaseId || menuItemId >= recentBaseId + 10) {
+        return false;
+    }
+
+    const juce::File file = processor.getRecentProjectFile(menuItemId - recentBaseId);
+    if (file.existsAsFile()) {
+        editor.openProject(file);
+    }
+    return true;
+}
+
+void MainMenuBarModel::addRecentRecordingsSubmenu(juce::PopupMenu& menu, CommonAudioProcessor& processor, int recentBaseId) {
+    juce::PopupMenu recordingsMenu;
+    const int added = processor.createRecentRecordingsPopupMenuItems(recordingsMenu, recentBaseId);
+    if (added == 0) {
+        recordingsMenu.addItem(recentBaseId, "(No Recent Recordings)", false);
+    }
+    menu.addSubMenu("Recent Recordings", recordingsMenu);
+}
+
+bool MainMenuBarModel::handleRecentRecordingMenuItem(int menuItemId, CommonAudioProcessor& processor, int recentBaseId) {
+    if (menuItemId < recentBaseId || menuItemId >= recentBaseId + 10) {
+        return false;
+    }
+
+    const juce::File file = processor.getRecentRecordingFile(menuItemId - recentBaseId);
+    if (file.existsAsFile()) {
+        file.startAsProcess();
+    }
+    return true;
+}
+
+void MainMenuBarModel::addRecordingPreferencesMenuItems(int topLevelMenuIndex, CommonAudioProcessor& processor, CommonPluginEditor& editor) {
+    addToggleMenuItem(topLevelMenuIndex, "Show Video After Export", [&processor] {
+        const bool enabled = processor.globalSettings.getBool("showVideoAfterExport", false);
+        processor.globalSettings.set("showVideoAfterExport", !enabled);
+        processor.globalSettings.save();
+    }, [&processor] { return processor.globalSettings.getBool("showVideoAfterExport", false); });
+    addMenuSeparator(topLevelMenuIndex);
+    addMenuItem(topLevelMenuIndex, "Recording Settings...", [&editor] { editor.openRecordingSettings(); });
+}
+
+void MainMenuBarModel::addMuteMenuItem(int topLevelMenuIndex, CommonAudioProcessor& processor) {
+    addToggleMenuItem(topLevelMenuIndex, "Mute", [&processor] {
+        processor.muteParameter->setBoolValueNotifyingHost(!processor.muteParameter->getBoolValue());
+    }, [&processor] { return processor.muteParameter->getBoolValue(); }, JUCE_MAC ? "Cmd+Shift+M" : "Ctrl+Shift+M");
+}
+
+void MainMenuBarModel::addStandaloneAudioSettingsMenuItem(int topLevelMenuIndex, CommonAudioProcessor& processor, CommonPluginEditor& editor) {
+    if (processor.wrapperType == juce::AudioProcessor::WrapperType::wrapperType_Standalone) {
+        addMenuSeparator(topLevelMenuIndex);
+        addMenuItem(topLevelMenuIndex, "Settings...", [&editor] { editor.openAudioSettings(); });
+    }
+}
+
+void MainMenuBarModel::addCommonInterfaceMenuItems(int topLevelMenuIndex, CommonAudioProcessor& processor, CommonPluginEditor& editor) {
+    addListenForSpecialKeysMenuItem(topLevelMenuIndex, processor);
+#if OSCI_PREMIUM
+    addToggleMenuItem(topLevelMenuIndex, "Keep Oscilloscope Window on Top", [&editor] {
+        editor.visualiser.setPopoutAlwaysOnTop(!editor.visualiser.isPopoutAlwaysOnTop());
+    }, [&editor] { return editor.visualiser.isPopoutAlwaysOnTop(); });
+#endif
+    if (processor.wrapperType == juce::AudioProcessor::WrapperType::wrapperType_Standalone) {
+        addToggleMenuItem(topLevelMenuIndex, "Full Screen", [&editor] { editor.toggleFullScreen(); }, [&editor] { return editor.isFullScreen(); }, "F11");
+        addMenuItem(topLevelMenuIndex, "Reset Window Size and Position", [&editor] { editor.resetWindowSizeAndPosition(); });
+    }
 }
 
 juce::StringArray MainMenuBarModel::getMenuBarNames() {

--- a/Source/components/menu/MainMenuBarModel.h
+++ b/Source/components/menu/MainMenuBarModel.h
@@ -2,6 +2,7 @@
 #include <JuceHeader.h>
 
 class CommonAudioProcessor;
+class CommonPluginEditor;
 
 class MainMenuBarModel : public juce::MenuBarModel {
 public:
@@ -9,6 +10,7 @@ public:
     ~MainMenuBarModel();
 
     void addTopLevelMenu(const juce::String& name);
+    void addStandardTopLevelMenus();
     void addMenuItem(int topLevelMenuIndex, const juce::String& name, std::function<void()> action, const juce::String& shortcutKey = {});
     void addMenuSeparator(int topLevelMenuIndex);
     // Adds a toggle (ticked) menu item whose tick state is provided dynamically via isTicked()
@@ -16,10 +18,20 @@ public:
     // Adds the common "Open Log File", "Open App Settings File", "Open Global Settings File"
     // items shared across all apps.
     void addDiagnosticsMenuItems(int topLevelMenuIndex, CommonAudioProcessor& processor);
+    void addSupportMenuItems(int topLevelMenuIndex, CommonAudioProcessor& processor, CommonPluginEditor& editor);
     // Adds the common "Undo"/"Redo" items backed by the processor's shared UndoManager.
     void addEditMenuItems(int topLevelMenuIndex, CommonAudioProcessor& processor);
     // Adds the shared "Listen for Special Keys" toggle item.
     void addListenForSpecialKeysMenuItem(int topLevelMenuIndex, CommonAudioProcessor& processor);
+    void addProjectMenuItems(int topLevelMenuIndex, CommonAudioProcessor& processor, CommonPluginEditor& editor);
+    void addRecentProjectsSubmenu(juce::PopupMenu& menu, CommonAudioProcessor& processor, int recentBaseId, int clearRecentId);
+    bool handleRecentProjectMenuItem(int menuItemId, CommonAudioProcessor& processor, CommonPluginEditor& editor, int recentBaseId, int clearRecentId);
+    void addRecentRecordingsSubmenu(juce::PopupMenu& menu, CommonAudioProcessor& processor, int recentBaseId);
+    bool handleRecentRecordingMenuItem(int menuItemId, CommonAudioProcessor& processor, int recentBaseId);
+    void addRecordingPreferencesMenuItems(int topLevelMenuIndex, CommonAudioProcessor& processor, CommonPluginEditor& editor);
+    void addMuteMenuItem(int topLevelMenuIndex, CommonAudioProcessor& processor);
+    void addStandaloneAudioSettingsMenuItem(int topLevelMenuIndex, CommonAudioProcessor& processor, CommonPluginEditor& editor);
+    void addCommonInterfaceMenuItems(int topLevelMenuIndex, CommonAudioProcessor& processor, CommonPluginEditor& editor);
     void resetMenuItems();
 
     std::function<void(juce::PopupMenu&, int)> customMenuLogic;

--- a/Source/components/menu/MainMenuBarModel.h
+++ b/Source/components/menu/MainMenuBarModel.h
@@ -10,8 +10,9 @@ public:
 
     void addTopLevelMenu(const juce::String& name);
     void addMenuItem(int topLevelMenuIndex, const juce::String& name, std::function<void()> action, const juce::String& shortcutKey = {});
+    void addMenuSeparator(int topLevelMenuIndex);
     // Adds a toggle (ticked) menu item whose tick state is provided dynamically via isTicked()
-    void addToggleMenuItem(int topLevelMenuIndex, const juce::String& name, std::function<void()> action, std::function<bool()> isTicked);
+    void addToggleMenuItem(int topLevelMenuIndex, const juce::String& name, std::function<void()> action, std::function<bool()> isTicked, const juce::String& shortcutKey = {});
     // Adds the common "Open Log File", "Open App Settings File", "Open Global Settings File"
     // items shared across all apps.
     void addDiagnosticsMenuItems(int topLevelMenuIndex, CommonAudioProcessor& processor);
@@ -37,6 +38,7 @@ private:
         std::function<bool()> isTicked; // optional tick state
         bool hasTick = false;
         juce::String shortcutKey;
+        bool isSeparator = false;
     };
 
     juce::StringArray topLevelMenuNames;

--- a/Source/components/menu/OsciMainMenuBarModel.cpp
+++ b/Source/components/menu/OsciMainMenuBarModel.cpp
@@ -30,18 +30,7 @@ void OsciMainMenuBarModel::resetMenuItems() {
 
     customMenuLogic = [this, fileMenu, videoMenu, audioMenu](juce::PopupMenu& menu, int topLevelMenuIndex) {
         if (topLevelMenuIndex == fileMenu) {
-            juce::PopupMenu recentMenu;
-            const int added = audioProcessor.createRecentProjectsPopupMenuItems(recentMenu,
-                                                                                RECENT_BASE_ID,
-                                                                                true,
-                                                                                true);
-            if (added == 0) {
-                recentMenu.addItem(RECENT_BASE_ID, "(No Recent Projects)", false);
-            }
-            recentMenu.addSeparator();
-            recentMenu.addItem(CLEAR_RECENT_PROJECTS_ID, "Clear Recent Projects", added > 0);
-
-            menu.addSubMenu("Open Recent", recentMenu);
+            addRecentProjectsSubmenu(menu, audioProcessor, RECENT_BASE_ID, CLEAR_RECENT_PROJECTS_ID);
             menu.addSeparator();
             return;
         }
@@ -109,12 +98,7 @@ void OsciMainMenuBarModel::resetMenuItems() {
 #endif
 #endif
 
-        juce::PopupMenu recordingsMenu;
-        const int added = audioProcessor.createRecentRecordingsPopupMenuItems(recordingsMenu, RECENT_RECORDING_BASE_ID);
-        if (added == 0) {
-            recordingsMenu.addItem(RECENT_RECORDING_BASE_ID, "(No Recent Recordings)", false);
-        }
-        menu.addSubMenu("Recent Recordings", recordingsMenu);
+        addRecentRecordingsSubmenu(menu, audioProcessor, RECENT_RECORDING_BASE_ID);
         menu.addSeparator();
     };
 
@@ -137,26 +121,11 @@ void OsciMainMenuBarModel::resetMenuItems() {
             return true;
         }
 
-        if (topLevelMenuIndex == fileMenu && menuItemID == CLEAR_RECENT_PROJECTS_ID) {
-            audioProcessor.clearRecentProjectFiles();
+        if (topLevelMenuIndex == fileMenu && handleRecentProjectMenuItem(menuItemID, audioProcessor, editor, RECENT_BASE_ID, CLEAR_RECENT_PROJECTS_ID)) {
             return true;
         }
 
-        if (topLevelMenuIndex == fileMenu && menuItemID >= RECENT_BASE_ID) {
-            const int index = menuItemID - RECENT_BASE_ID;
-            const auto file = audioProcessor.getRecentProjectFile(index);
-            if (file != juce::File() && file.existsAsFile()) {
-                editor.openProject(file);
-            }
-
-            return true;
-        }
-
-        if (topLevelMenuIndex == videoMenu && menuItemID >= RECENT_RECORDING_BASE_ID && menuItemID < RECENT_RECORDING_BASE_ID + 10) {
-            const auto file = audioProcessor.getRecentRecordingFile(menuItemID - RECENT_RECORDING_BASE_ID);
-            if (file.existsAsFile()) {
-                file.startAsProcess();
-            }
+        if (topLevelMenuIndex == videoMenu && handleRecentRecordingMenuItem(menuItemID, audioProcessor, RECENT_RECORDING_BASE_ID)) {
             return true;
         }
 
@@ -184,30 +153,12 @@ void OsciMainMenuBarModel::resetMenuItems() {
 #endif
 #endif
 
-        if (topLevelMenuIndex != fileMenu) {
-            return false;
-        }
-
-        if (menuItemID < RECENT_BASE_ID) {
-            return false;
-        }
-
-        return true;
+        return false;
     };
 
-    addTopLevelMenu("File");
-    addTopLevelMenu("Edit");
-    addTopLevelMenu("About");
-    addTopLevelMenu("Video");
-    addTopLevelMenu("Audio");
-    addTopLevelMenu("Interface");
+    addStandardTopLevelMenus();
 
-    addMenuItem(fileMenu, "Open Project", [this] { editor.openProject(); }, JUCE_MAC ? "Cmd+O" : "Ctrl+O");
-    addMenuItem(fileMenu, "Save Project", [this] { editor.saveProject(); }, JUCE_MAC ? "Cmd+S" : "Ctrl+S");
-    addMenuItem(fileMenu, "Save Project As", [this] { editor.saveProjectAs(); }, JUCE_MAC ? "Cmd+Shift+S" : "Ctrl+Shift+S");
-    if (editor.processor.wrapperType == juce::AudioProcessor::WrapperType::wrapperType_Standalone) {
-        addMenuItem(fileMenu, "Create New Project", [this] { editor.resetToDefault(); }, JUCE_MAC ? "Cmd+N" : "Ctrl+N");
-    }
+    addProjectMenuItems(fileMenu, audioProcessor, editor);
 
     addEditMenuItems(editMenu, audioProcessor);
 
@@ -244,13 +195,7 @@ void OsciMainMenuBarModel::resetMenuItems() {
 
         editor.showOverlay(AboutComponent::createOverlay(aboutInfo));
     });
-    addMenuItem(aboutMenu, "License and Updates...", [this] {
-        editor.openLicenseAndUpdates();
-    });
-    addMenuItem(aboutMenu, "Send Feedback...", [this] {
-        editor.openFeedback();
-    });
-    addDiagnosticsMenuItems(aboutMenu, audioProcessor);
+    addSupportMenuItems(aboutMenu, audioProcessor, editor);
     addMenuItem(aboutMenu, "Randomize Blender Port", [this] {
         audioProcessor.setObjectServerPort(juce::Random::getSystemRandom().nextInt(juce::Range<int>(51600, 51700)));
     });
@@ -268,19 +213,9 @@ void OsciMainMenuBarModel::resetMenuItems() {
         editor.showPremiumSplashScreen();
 #endif
     });
-    addToggleMenuItem(videoMenu, "Show Video After Export", [this] {
-        const bool enabled = audioProcessor.globalSettings.getBool("showVideoAfterExport", false);
-        audioProcessor.globalSettings.set("showVideoAfterExport", !enabled);
-        audioProcessor.globalSettings.save();
-    }, [this] { return audioProcessor.globalSettings.getBool("showVideoAfterExport", false); });
-    addMenuSeparator(videoMenu);
-    addMenuItem(videoMenu, "Recording Settings...", [this] {
-        editor.openRecordingSettings();
-    });
+    addRecordingPreferencesMenuItems(videoMenu, audioProcessor, editor);
 
-    addToggleMenuItem(audioMenu, "Mute", [this] {
-        audioProcessor.muteParameter->setBoolValueNotifyingHost(!audioProcessor.muteParameter->getBoolValue());
-    }, [this] { return audioProcessor.muteParameter->getBoolValue(); }, JUCE_MAC ? "Cmd+Shift+M" : "Ctrl+Shift+M");
+    addMuteMenuItem(audioMenu, audioProcessor);
     addToggleMenuItem(audioMenu, "Swap X/Y", [this] {
         audioProcessor.swapXYOutput->setBoolValueNotifyingHost(!audioProcessor.swapXYOutput->getBoolValue());
     }, [this] { return audioProcessor.swapXYOutput->getBoolValue(); });
@@ -290,12 +225,7 @@ void OsciMainMenuBarModel::resetMenuItems() {
     addToggleMenuItem(audioMenu, "Invert Y", [this] {
         audioProcessor.invertYOutput->setBoolValueNotifyingHost(!audioProcessor.invertYOutput->getBoolValue());
     }, [this] { return audioProcessor.invertYOutput->getBoolValue(); });
-    if (editor.processor.wrapperType == juce::AudioProcessor::WrapperType::wrapperType_Standalone) {
-        addMenuSeparator(audioMenu);
-        addMenuItem(audioMenu, "Settings...", [this] {
-            editor.openAudioSettings();
-        });
-    }
+    addStandaloneAudioSettingsMenuItem(audioMenu, audioProcessor, editor);
     // Interface menu
     addToggleMenuItem(interfaceMenu, "Preview effect on hover", [this] {
         bool current = audioProcessor.globalSettings.getBool("previewEffectOnHover", true);
@@ -313,18 +243,7 @@ void OsciMainMenuBarModel::resetMenuItems() {
         }, [this] { return audioProcessor.globalSettings.getBool("previewEffectOnHover", true);
     });
 
-    addListenForSpecialKeysMenuItem(interfaceMenu, audioProcessor);
-
-#if OSCI_PREMIUM
-    addToggleMenuItem(interfaceMenu, "Keep Oscilloscope Window on Top", [this] {
-        editor.visualiser.setPopoutAlwaysOnTop(!editor.visualiser.isPopoutAlwaysOnTop());
-    }, [this] { return editor.visualiser.isPopoutAlwaysOnTop(); });
-#endif
-
-    if (editor.processor.wrapperType == juce::AudioProcessor::WrapperType::wrapperType_Standalone) {
-        addToggleMenuItem(interfaceMenu, "Full Screen", [this] { editor.toggleFullScreen(); }, [this] { return editor.isFullScreen(); }, "F11");
-        addMenuItem(interfaceMenu, "Reset Window Size and Position", [this] { editor.resetWindowSizeAndPosition(); });
-    }
+    addCommonInterfaceMenuItems(interfaceMenu, audioProcessor, editor);
 
     addToggleMenuItem(interfaceMenu, "Show MIDI Keyboard", [this] {
         bool current = audioProcessor.globalSettings.getBool("showMidiKeyboard", true);

--- a/Source/components/menu/OsciMainMenuBarModel.cpp
+++ b/Source/components/menu/OsciMainMenuBarModel.cpp
@@ -315,6 +315,12 @@ void OsciMainMenuBarModel::resetMenuItems() {
 
     addListenForSpecialKeysMenuItem(interfaceMenu, audioProcessor);
 
+#if OSCI_PREMIUM
+    addToggleMenuItem(interfaceMenu, "Keep Oscilloscope Window on Top", [this] {
+        editor.visualiser.setPopoutAlwaysOnTop(!editor.visualiser.isPopoutAlwaysOnTop());
+    }, [this] { return editor.visualiser.isPopoutAlwaysOnTop(); });
+#endif
+
     if (editor.processor.wrapperType == juce::AudioProcessor::WrapperType::wrapperType_Standalone) {
         addToggleMenuItem(interfaceMenu, "Full Screen", [this] { editor.toggleFullScreen(); }, [this] { return editor.isFullScreen(); }, "F11");
         addMenuItem(interfaceMenu, "Reset Window Size and Position", [this] { editor.resetWindowSizeAndPosition(); });

--- a/Source/components/menu/OsciMainMenuBarModel.cpp
+++ b/Source/components/menu/OsciMainMenuBarModel.cpp
@@ -272,7 +272,6 @@ void OsciMainMenuBarModel::resetMenuItems() {
         const bool enabled = audioProcessor.globalSettings.getBool("showVideoAfterExport", false);
         audioProcessor.globalSettings.set("showVideoAfterExport", !enabled);
         audioProcessor.globalSettings.save();
-        resetMenuItems();
     }, [this] { return audioProcessor.globalSettings.getBool("showVideoAfterExport", false); });
     addMenuSeparator(videoMenu);
     addMenuItem(videoMenu, "Recording Settings...", [this] {

--- a/Source/components/menu/OsciMainMenuBarModel.cpp
+++ b/Source/components/menu/OsciMainMenuBarModel.cpp
@@ -11,16 +11,21 @@ OsciMainMenuBarModel::OsciMainMenuBarModel(OscirenderAudioProcessor& p, Oscirend
 void OsciMainMenuBarModel::resetMenuItems() {
     MainMenuBarModel::resetMenuItems();
 
+    constexpr int CLEAR_RECENT_PROJECTS_ID = 900;
     constexpr int RECENT_BASE_ID = 1000;
     constexpr int TEXTURE_INPUT_DISCONNECT_ID = 2000;
     constexpr int TEXTURE_INPUT_SOURCE_BASE_ID = 2100;
     constexpr int SAMPLE_RATE_BASE_ID = 3000;
+    constexpr int MIDI_CHANNEL_BASE_ID = 4000;
+    constexpr int MIDI_PANIC_ID = 4100;
+    constexpr int MIDI_KILL_ID = 4101;
+    constexpr int RECENT_RECORDING_BASE_ID = 6000;
     constexpr int fileMenu = 0;
     constexpr int editMenu = 1;
     constexpr int aboutMenu = 2;
     constexpr int videoMenu = 3;
     int nextMenu = 4;
-    const int audioMenu = (editor.processor.wrapperType == juce::AudioProcessor::WrapperType::wrapperType_Standalone) ? nextMenu++ : -1;
+    const int audioMenu = nextMenu++;
     const int interfaceMenu = nextMenu;
 
     customMenuLogic = [this, fileMenu, videoMenu, audioMenu](juce::PopupMenu& menu, int topLevelMenuIndex) {
@@ -33,6 +38,8 @@ void OsciMainMenuBarModel::resetMenuItems() {
             if (added == 0) {
                 recentMenu.addItem(RECENT_BASE_ID, "(No Recent Projects)", false);
             }
+            recentMenu.addSeparator();
+            recentMenu.addItem(CLEAR_RECENT_PROJECTS_ID, "Clear Recent Projects", added > 0);
 
             menu.addSubMenu("Open Recent", recentMenu);
             menu.addSeparator();
@@ -41,6 +48,20 @@ void OsciMainMenuBarModel::resetMenuItems() {
 
         if (topLevelMenuIndex == audioMenu) {
             InternalSampleRateMenu::addSubmenu(menu, audioProcessor, SAMPLE_RATE_BASE_ID);
+
+            juce::PopupMenu channelMenu;
+            const int selectedChannel = audioProcessor.midiInputChannel->getValueUnnormalised();
+            channelMenu.addItem(MIDI_CHANNEL_BASE_ID, "Omni", true, selectedChannel == 0);
+            for (int channel = 1; channel <= 16; channel++) {
+                channelMenu.addItem(MIDI_CHANNEL_BASE_ID + channel, "Channel " + juce::String(channel), true, selectedChannel == channel);
+            }
+
+            juce::PopupMenu midiMenu;
+            midiMenu.addSubMenu("Input Channel", channelMenu);
+            midiMenu.addSeparator();
+            midiMenu.addItem(MIDI_PANIC_ID, "Panic (Release All Notes)");
+            midiMenu.addItem(MIDI_KILL_ID, "Kill Voices Immediately");
+            menu.addSubMenu("MIDI", midiMenu);
             return;
         }
 
@@ -87,12 +108,37 @@ void OsciMainMenuBarModel::resetMenuItems() {
         menu.addSeparator();
 #endif
 #endif
+
+        juce::PopupMenu recordingsMenu;
+        const int added = audioProcessor.createRecentRecordingsPopupMenuItems(recordingsMenu, RECENT_RECORDING_BASE_ID);
+        if (added == 0) {
+            recordingsMenu.addItem(RECENT_RECORDING_BASE_ID, "(No Recent Recordings)", false);
+        }
+        menu.addSubMenu("Recent Recordings", recordingsMenu);
+        menu.addSeparator();
     };
 
     customMenuSelectedLogic = [this, fileMenu, videoMenu, audioMenu](int menuItemID, int topLevelMenuIndex) {
+        if (topLevelMenuIndex == audioMenu && menuItemID >= MIDI_CHANNEL_BASE_ID && menuItemID <= MIDI_CHANNEL_BASE_ID + 16) {
+            audioProcessor.midiInputChannel->setUnnormalisedValueNotifyingHost(menuItemID - MIDI_CHANNEL_BASE_ID);
+            return true;
+        }
+        if (topLevelMenuIndex == audioMenu && menuItemID == MIDI_PANIC_ID) {
+            audioProcessor.sendMidiPanic(false);
+            return true;
+        }
+        if (topLevelMenuIndex == audioMenu && menuItemID == MIDI_KILL_ID) {
+            audioProcessor.sendMidiPanic(true);
+            return true;
+        }
         if (topLevelMenuIndex == audioMenu
             && InternalSampleRateMenu::handleMenuId(menuItemID, SAMPLE_RATE_BASE_ID, audioProcessor, [this] { editor.showPremiumSplashScreen(); })) {
             resetMenuItems();
+            return true;
+        }
+
+        if (topLevelMenuIndex == fileMenu && menuItemID == CLEAR_RECENT_PROJECTS_ID) {
+            audioProcessor.clearRecentProjectFiles();
             return true;
         }
 
@@ -103,6 +149,14 @@ void OsciMainMenuBarModel::resetMenuItems() {
                 editor.openProject(file);
             }
 
+            return true;
+        }
+
+        if (topLevelMenuIndex == videoMenu && menuItemID >= RECENT_RECORDING_BASE_ID && menuItemID < RECENT_RECORDING_BASE_ID + 10) {
+            const auto file = audioProcessor.getRecentRecordingFile(menuItemID - RECENT_RECORDING_BASE_ID);
+            if (file.existsAsFile()) {
+                file.startAsProcess();
+            }
             return true;
         }
 
@@ -145,16 +199,14 @@ void OsciMainMenuBarModel::resetMenuItems() {
     addTopLevelMenu("Edit");
     addTopLevelMenu("About");
     addTopLevelMenu("Video");
-    if (editor.processor.wrapperType == juce::AudioProcessor::WrapperType::wrapperType_Standalone) {
-        addTopLevelMenu("Audio");
-    }
+    addTopLevelMenu("Audio");
     addTopLevelMenu("Interface");
 
-    addMenuItem(fileMenu, "Open Project", [this] { editor.openProject(); });
-    addMenuItem(fileMenu, "Save Project", [this] { editor.saveProject(); });
-    addMenuItem(fileMenu, "Save Project As", [this] { editor.saveProjectAs(); });
+    addMenuItem(fileMenu, "Open Project", [this] { editor.openProject(); }, JUCE_MAC ? "Cmd+O" : "Ctrl+O");
+    addMenuItem(fileMenu, "Save Project", [this] { editor.saveProject(); }, JUCE_MAC ? "Cmd+S" : "Ctrl+S");
+    addMenuItem(fileMenu, "Save Project As", [this] { editor.saveProjectAs(); }, JUCE_MAC ? "Cmd+Shift+S" : "Ctrl+Shift+S");
     if (editor.processor.wrapperType == juce::AudioProcessor::WrapperType::wrapperType_Standalone) {
-        addMenuItem(fileMenu, "Create New Project", [this] { editor.resetToDefault(); });
+        addMenuItem(fileMenu, "Create New Project", [this] { editor.resetToDefault(); }, JUCE_MAC ? "Cmd+N" : "Ctrl+N");
     }
 
     addEditMenuItems(editMenu, audioProcessor);
@@ -209,10 +261,6 @@ void OsciMainMenuBarModel::resetMenuItems() {
     });
 #endif
 
-    addMenuItem(videoMenu, "Recording Settings...", [this] {
-        editor.openRecordingSettings();
-    });
-
     addMenuItem(videoMenu, "Render Audio File to Video...", [this] {
 #if OSCI_PREMIUM
         editor.renderAudioFileToVideo();
@@ -220,13 +268,35 @@ void OsciMainMenuBarModel::resetMenuItems() {
         editor.showPremiumSplashScreen();
 #endif
     });
+    addToggleMenuItem(videoMenu, "Show Video After Export", [this] {
+        const bool enabled = audioProcessor.globalSettings.getBool("showVideoAfterExport", false);
+        audioProcessor.globalSettings.set("showVideoAfterExport", !enabled);
+        audioProcessor.globalSettings.save();
+        resetMenuItems();
+    }, [this] { return audioProcessor.globalSettings.getBool("showVideoAfterExport", false); });
+    addMenuSeparator(videoMenu);
+    addMenuItem(videoMenu, "Recording Settings...", [this] {
+        editor.openRecordingSettings();
+    });
 
+    addToggleMenuItem(audioMenu, "Mute", [this] {
+        audioProcessor.muteParameter->setBoolValueNotifyingHost(!audioProcessor.muteParameter->getBoolValue());
+    }, [this] { return audioProcessor.muteParameter->getBoolValue(); }, JUCE_MAC ? "Cmd+Shift+M" : "Ctrl+Shift+M");
+    addToggleMenuItem(audioMenu, "Swap X/Y", [this] {
+        audioProcessor.swapXYOutput->setBoolValueNotifyingHost(!audioProcessor.swapXYOutput->getBoolValue());
+    }, [this] { return audioProcessor.swapXYOutput->getBoolValue(); });
+    addToggleMenuItem(audioMenu, "Invert X", [this] {
+        audioProcessor.invertXOutput->setBoolValueNotifyingHost(!audioProcessor.invertXOutput->getBoolValue());
+    }, [this] { return audioProcessor.invertXOutput->getBoolValue(); });
+    addToggleMenuItem(audioMenu, "Invert Y", [this] {
+        audioProcessor.invertYOutput->setBoolValueNotifyingHost(!audioProcessor.invertYOutput->getBoolValue());
+    }, [this] { return audioProcessor.invertYOutput->getBoolValue(); });
     if (editor.processor.wrapperType == juce::AudioProcessor::WrapperType::wrapperType_Standalone) {
+        addMenuSeparator(audioMenu);
         addMenuItem(audioMenu, "Settings...", [this] {
             editor.openAudioSettings();
         });
     }
-
     // Interface menu
     addToggleMenuItem(interfaceMenu, "Preview effect on hover", [this] {
         bool current = audioProcessor.globalSettings.getBool("previewEffectOnHover", true);
@@ -245,6 +315,11 @@ void OsciMainMenuBarModel::resetMenuItems() {
     });
 
     addListenForSpecialKeysMenuItem(interfaceMenu, audioProcessor);
+
+    if (editor.processor.wrapperType == juce::AudioProcessor::WrapperType::wrapperType_Standalone) {
+        addToggleMenuItem(interfaceMenu, "Full Screen", [this] { editor.toggleFullScreen(); }, [this] { return editor.isFullScreen(); }, "F11");
+        addMenuItem(interfaceMenu, "Reset Window Size and Position", [this] { editor.resetWindowSizeAndPosition(); });
+    }
 
     addToggleMenuItem(interfaceMenu, "Show MIDI Keyboard", [this] {
         bool current = audioProcessor.globalSettings.getBool("showMidiKeyboard", true);

--- a/Source/components/menu/SosciMainMenuBarModel.cpp
+++ b/Source/components/menu/SosciMainMenuBarModel.cpp
@@ -14,12 +14,7 @@ void SosciMainMenuBarModel::resetMenuItems() {
     constexpr int RECENT_BASE_ID = 1000;
     constexpr int RECENT_RECORDING_BASE_ID = 2000;
 
-    addTopLevelMenu("File");
-    addTopLevelMenu("Edit");
-    addTopLevelMenu("About");
-    addTopLevelMenu("Video");
-    addTopLevelMenu("Audio");
-    addTopLevelMenu("Interface");
+    addStandardTopLevelMenus();
 
     const int fileMenu      = 0;
     const int editMenu      = 1;
@@ -39,12 +34,7 @@ void SosciMainMenuBarModel::resetMenuItems() {
     // This is a hack - ideally I would improve the MainMenuBarModel class to allow for submenus
     customMenuLogic = [this, examples, fileMenu, videoMenu](juce::PopupMenu& menu, int topLevelMenuIndex) {
         if (topLevelMenuIndex == videoMenu) {
-            juce::PopupMenu recordingsMenu;
-            const int added = processor.createRecentRecordingsPopupMenuItems(recordingsMenu, RECENT_RECORDING_BASE_ID);
-            if (added == 0) {
-                recordingsMenu.addItem(RECENT_RECORDING_BASE_ID, "(No Recent Recordings)", false);
-            }
-            menu.addSubMenu("Recent Recordings", recordingsMenu);
+            addRecentRecordingsSubmenu(menu, processor, RECENT_RECORDING_BASE_ID);
             menu.addSeparator();
             return;
         }
@@ -53,18 +43,7 @@ void SosciMainMenuBarModel::resetMenuItems() {
             return;
         }
 
-        juce::PopupMenu recentMenu;
-        const int added = processor.createRecentProjectsPopupMenuItems(recentMenu,
-                                                                       RECENT_BASE_ID,
-                                                                       true,
-                                                                       true);
-        if (added == 0) {
-            recentMenu.addItem(RECENT_BASE_ID, "(No Recent Projects)", false);
-        }
-        recentMenu.addSeparator();
-        recentMenu.addItem(CLEAR_RECENT_PROJECTS_ID, "Clear Recent Projects", added > 0);
-
-        menu.addSubMenu("Open Recent", recentMenu);
+        addRecentProjectsSubmenu(menu, processor, RECENT_BASE_ID, CLEAR_RECENT_PROJECTS_ID);
 
         juce::PopupMenu submenu;
         for (int i = 0; i < (int) examples.size(); i++) {
@@ -76,11 +55,7 @@ void SosciMainMenuBarModel::resetMenuItems() {
     };
 
     customMenuSelectedLogic = [this, examples, fileMenu, videoMenu](int menuItemID, int topLevelMenuIndex) {
-        if (topLevelMenuIndex == videoMenu && menuItemID >= RECENT_RECORDING_BASE_ID && menuItemID < RECENT_RECORDING_BASE_ID + 10) {
-            const auto file = processor.getRecentRecordingFile(menuItemID - RECENT_RECORDING_BASE_ID);
-            if (file.existsAsFile()) {
-                file.startAsProcess();
-            }
+        if (topLevelMenuIndex == videoMenu && handleRecentRecordingMenuItem(menuItemID, processor, RECENT_RECORDING_BASE_ID)) {
             return true;
         }
 
@@ -88,16 +63,7 @@ void SosciMainMenuBarModel::resetMenuItems() {
             return false;
         }
 
-        if (menuItemID == CLEAR_RECENT_PROJECTS_ID) {
-            processor.clearRecentProjectFiles();
-            return true;
-        }
-
-        if (menuItemID >= RECENT_BASE_ID) {
-            const int index = menuItemID - RECENT_BASE_ID;
-            const auto file = processor.getRecentProjectFile(index);
-            if (file != juce::File() && file.existsAsFile())
-                editor.openProject(file);
+        if (handleRecentProjectMenuItem(menuItemID, processor, editor, RECENT_BASE_ID, CLEAR_RECENT_PROJECTS_ID)) {
             return true;
         }
 
@@ -121,12 +87,7 @@ void SosciMainMenuBarModel::resetMenuItems() {
             }
         });
     });
-    addMenuItem(fileMenu, "Open Project", [&]() { editor.openProject(); }, JUCE_MAC ? "Cmd+O" : "Ctrl+O");
-    addMenuItem(fileMenu, "Save Project", [&]() { editor.saveProject(); }, JUCE_MAC ? "Cmd+S" : "Ctrl+S");
-    addMenuItem(fileMenu, "Save Project As", [&]() { editor.saveProjectAs(); }, JUCE_MAC ? "Cmd+Shift+S" : "Ctrl+Shift+S");
-    if (editor.processor.wrapperType == juce::AudioProcessor::WrapperType::wrapperType_Standalone) {
-        addMenuItem(fileMenu, "Create New Project", [&]() { editor.resetToDefault(); }, JUCE_MAC ? "Cmd+N" : "Ctrl+N");
-    }
+    addProjectMenuItems(fileMenu, processor, editor);
 
     addEditMenuItems(editMenu, processor);
 
@@ -160,26 +121,12 @@ void SosciMainMenuBarModel::resetMenuItems() {
 
         editor.showOverlay(AboutComponent::createOverlay(aboutInfo));
     });
-    addMenuItem(aboutMenu, "License and Updates...", [&]() {
-        editor.openLicenseAndUpdates();
-    });
-    addMenuItem(aboutMenu, "Send Feedback...", [this] {
-        editor.openFeedback();
-    });
-    addDiagnosticsMenuItems(aboutMenu, processor);
+    addSupportMenuItems(aboutMenu, processor, editor);
 
     addMenuItem(videoMenu, "Render Audio File to Video...", [this] {
         editor.renderAudioFileToVideo();
     });
-    addToggleMenuItem(videoMenu, "Show Video After Export", [this] {
-        const bool enabled = processor.globalSettings.getBool("showVideoAfterExport", false);
-        processor.globalSettings.set("showVideoAfterExport", !enabled);
-        processor.globalSettings.save();
-    }, [this] { return processor.globalSettings.getBool("showVideoAfterExport", false); });
-    addMenuSeparator(videoMenu);
-    addMenuItem(videoMenu, "Recording Settings...", [this] {
-        editor.openRecordingSettings();
-    });
+    addRecordingPreferencesMenuItems(videoMenu, processor, editor);
 
     addMenuItem(audioMenu, "Force Disable Brightness Input", [&]() {
         processor.forceDisableBrightnessInput = !processor.forceDisableBrightnessInput;
@@ -198,23 +145,9 @@ void SosciMainMenuBarModel::resetMenuItems() {
         menuItemsChanged();
     });
 
-    addToggleMenuItem(audioMenu, "Mute", [this] {
-        processor.muteParameter->setBoolValueNotifyingHost(!processor.muteParameter->getBoolValue());
-    }, [this] { return processor.muteParameter->getBoolValue(); }, JUCE_MAC ? "Cmd+Shift+M" : "Ctrl+Shift+M");
-    if (editor.processor.wrapperType == juce::AudioProcessor::WrapperType::wrapperType_Standalone) {
-        addMenuSeparator(audioMenu);
-        addMenuItem(audioMenu, "Settings...", [&]() { editor.openAudioSettings(); });
-    }
+    addMuteMenuItem(audioMenu, processor);
+    addStandaloneAudioSettingsMenuItem(audioMenu, processor, editor);
 
     // Interface menu
-    addListenForSpecialKeysMenuItem(interfaceMenu, processor);
-#if OSCI_PREMIUM
-    addToggleMenuItem(interfaceMenu, "Keep Oscilloscope Window on Top", [this] {
-        editor.visualiser.setPopoutAlwaysOnTop(!editor.visualiser.isPopoutAlwaysOnTop());
-    }, [this] { return editor.visualiser.isPopoutAlwaysOnTop(); });
-#endif
-    if (editor.processor.wrapperType == juce::AudioProcessor::WrapperType::wrapperType_Standalone) {
-        addToggleMenuItem(interfaceMenu, "Full Screen", [this] { editor.toggleFullScreen(); }, [this] { return editor.isFullScreen(); }, "F11");
-        addMenuItem(interfaceMenu, "Reset Window Size and Position", [this] { editor.resetWindowSizeAndPosition(); });
-    }
+    addCommonInterfaceMenuItems(interfaceMenu, processor, editor);
 }

--- a/Source/components/menu/SosciMainMenuBarModel.cpp
+++ b/Source/components/menu/SosciMainMenuBarModel.cpp
@@ -10,7 +10,9 @@ SosciMainMenuBarModel::SosciMainMenuBarModel(SosciPluginEditor& e, SosciAudioPro
 void SosciMainMenuBarModel::resetMenuItems() {
     MainMenuBarModel::resetMenuItems();
 
+    constexpr int CLEAR_RECENT_PROJECTS_ID = 900;
     constexpr int RECENT_BASE_ID = 1000;
+    constexpr int RECENT_RECORDING_BASE_ID = 2000;
 
     addTopLevelMenu("File");
     addTopLevelMenu("Edit");
@@ -35,17 +37,32 @@ void SosciMainMenuBarModel::resetMenuItems() {
     };
 
     // This is a hack - ideally I would improve the MainMenuBarModel class to allow for submenus
-    customMenuLogic = [this, examples](juce::PopupMenu& menu, int topLevelMenuIndex) {
-        if (topLevelMenuIndex != 0)
+    customMenuLogic = [this, examples, fileMenu, videoMenu](juce::PopupMenu& menu, int topLevelMenuIndex) {
+        if (topLevelMenuIndex == videoMenu) {
+            juce::PopupMenu recordingsMenu;
+            const int added = processor.createRecentRecordingsPopupMenuItems(recordingsMenu, RECENT_RECORDING_BASE_ID);
+            if (added == 0) {
+                recordingsMenu.addItem(RECENT_RECORDING_BASE_ID, "(No Recent Recordings)", false);
+            }
+            menu.addSubMenu("Recent Recordings", recordingsMenu);
+            menu.addSeparator();
             return;
+        }
+
+        if (topLevelMenuIndex != fileMenu) {
+            return;
+        }
 
         juce::PopupMenu recentMenu;
         const int added = processor.createRecentProjectsPopupMenuItems(recentMenu,
                                                                        RECENT_BASE_ID,
                                                                        true,
                                                                        true);
-        if (added == 0)
+        if (added == 0) {
             recentMenu.addItem(RECENT_BASE_ID, "(No Recent Projects)", false);
+        }
+        recentMenu.addSeparator();
+        recentMenu.addItem(CLEAR_RECENT_PROJECTS_ID, "Clear Recent Projects", added > 0);
 
         menu.addSubMenu("Open Recent", recentMenu);
 
@@ -58,9 +75,23 @@ void SosciMainMenuBarModel::resetMenuItems() {
         menu.addSeparator();
     };
 
-    customMenuSelectedLogic = [this, examples](int menuItemID, int topLevelMenuIndex) {
-        if (topLevelMenuIndex != 0)
+    customMenuSelectedLogic = [this, examples, fileMenu, videoMenu](int menuItemID, int topLevelMenuIndex) {
+        if (topLevelMenuIndex == videoMenu && menuItemID >= RECENT_RECORDING_BASE_ID && menuItemID < RECENT_RECORDING_BASE_ID + 10) {
+            const auto file = processor.getRecentRecordingFile(menuItemID - RECENT_RECORDING_BASE_ID);
+            if (file.existsAsFile()) {
+                file.startAsProcess();
+            }
+            return true;
+        }
+
+        if (topLevelMenuIndex != fileMenu) {
             return false;
+        }
+
+        if (menuItemID == CLEAR_RECENT_PROJECTS_ID) {
+            processor.clearRecentProjectFiles();
+            return true;
+        }
 
         if (menuItemID >= RECENT_BASE_ID) {
             const int index = menuItemID - RECENT_BASE_ID;
@@ -90,11 +121,11 @@ void SosciMainMenuBarModel::resetMenuItems() {
             }
         });
     });
-    addMenuItem(fileMenu, "Open Project", [&]() { editor.openProject(); });
-    addMenuItem(fileMenu, "Save Project", [&]() { editor.saveProject(); });
-    addMenuItem(fileMenu, "Save Project As", [&]() { editor.saveProjectAs(); });
+    addMenuItem(fileMenu, "Open Project", [&]() { editor.openProject(); }, JUCE_MAC ? "Cmd+O" : "Ctrl+O");
+    addMenuItem(fileMenu, "Save Project", [&]() { editor.saveProject(); }, JUCE_MAC ? "Cmd+S" : "Ctrl+S");
+    addMenuItem(fileMenu, "Save Project As", [&]() { editor.saveProjectAs(); }, JUCE_MAC ? "Cmd+Shift+S" : "Ctrl+Shift+S");
     if (editor.processor.wrapperType == juce::AudioProcessor::WrapperType::wrapperType_Standalone) {
-        addMenuItem(fileMenu, "Create New Project", [&]() { editor.resetToDefault(); });
+        addMenuItem(fileMenu, "Create New Project", [&]() { editor.resetToDefault(); }, JUCE_MAC ? "Cmd+N" : "Ctrl+N");
     }
 
     addEditMenuItems(editMenu, processor);
@@ -137,12 +168,18 @@ void SosciMainMenuBarModel::resetMenuItems() {
     });
     addDiagnosticsMenuItems(aboutMenu, processor);
 
-    addMenuItem(videoMenu, "Settings...", [this] {
-        editor.openRecordingSettings();
-    });
-
     addMenuItem(videoMenu, "Render Audio File to Video...", [this] {
         editor.renderAudioFileToVideo();
+    });
+    addToggleMenuItem(videoMenu, "Show Video After Export", [this] {
+        const bool enabled = processor.globalSettings.getBool("showVideoAfterExport", false);
+        processor.globalSettings.set("showVideoAfterExport", !enabled);
+        processor.globalSettings.save();
+        resetMenuItems();
+    }, [this] { return processor.globalSettings.getBool("showVideoAfterExport", false); });
+    addMenuSeparator(videoMenu);
+    addMenuItem(videoMenu, "Recording Settings...", [this] {
+        editor.openRecordingSettings();
     });
 
     addMenuItem(audioMenu, "Force Disable Brightness Input", [&]() {
@@ -162,10 +199,18 @@ void SosciMainMenuBarModel::resetMenuItems() {
         menuItemsChanged();
     });
 
+    addToggleMenuItem(audioMenu, "Mute", [this] {
+        processor.muteParameter->setBoolValueNotifyingHost(!processor.muteParameter->getBoolValue());
+    }, [this] { return processor.muteParameter->getBoolValue(); }, JUCE_MAC ? "Cmd+Shift+M" : "Ctrl+Shift+M");
     if (editor.processor.wrapperType == juce::AudioProcessor::WrapperType::wrapperType_Standalone) {
+        addMenuSeparator(audioMenu);
         addMenuItem(audioMenu, "Settings...", [&]() { editor.openAudioSettings(); });
     }
 
     // Interface menu
     addListenForSpecialKeysMenuItem(interfaceMenu, processor);
+    if (editor.processor.wrapperType == juce::AudioProcessor::WrapperType::wrapperType_Standalone) {
+        addToggleMenuItem(interfaceMenu, "Full Screen", [this] { editor.toggleFullScreen(); }, [this] { return editor.isFullScreen(); }, "F11");
+        addMenuItem(interfaceMenu, "Reset Window Size and Position", [this] { editor.resetWindowSizeAndPosition(); });
+    }
 }

--- a/Source/components/menu/SosciMainMenuBarModel.cpp
+++ b/Source/components/menu/SosciMainMenuBarModel.cpp
@@ -175,7 +175,6 @@ void SosciMainMenuBarModel::resetMenuItems() {
         const bool enabled = processor.globalSettings.getBool("showVideoAfterExport", false);
         processor.globalSettings.set("showVideoAfterExport", !enabled);
         processor.globalSettings.save();
-        resetMenuItems();
     }, [this] { return processor.globalSettings.getBool("showVideoAfterExport", false); });
     addMenuSeparator(videoMenu);
     addMenuItem(videoMenu, "Recording Settings...", [this] {

--- a/Source/components/menu/SosciMainMenuBarModel.cpp
+++ b/Source/components/menu/SosciMainMenuBarModel.cpp
@@ -208,6 +208,11 @@ void SosciMainMenuBarModel::resetMenuItems() {
 
     // Interface menu
     addListenForSpecialKeysMenuItem(interfaceMenu, processor);
+#if OSCI_PREMIUM
+    addToggleMenuItem(interfaceMenu, "Keep Oscilloscope Window on Top", [this] {
+        editor.visualiser.setPopoutAlwaysOnTop(!editor.visualiser.isPopoutAlwaysOnTop());
+    }, [this] { return editor.visualiser.isPopoutAlwaysOnTop(); });
+#endif
     if (editor.processor.wrapperType == juce::AudioProcessor::WrapperType::wrapperType_Standalone) {
         addToggleMenuItem(interfaceMenu, "Full Screen", [this] { editor.toggleFullScreen(); }, [this] { return editor.isFullScreen(); }, "F11");
         addMenuItem(interfaceMenu, "Reset Window Size and Position", [this] { editor.resetWindowSizeAndPosition(); });

--- a/Source/components/panels/SettingsComponent.cpp
+++ b/Source/components/panels/SettingsComponent.cpp
@@ -253,6 +253,22 @@ SettingsComponent::~SettingsComponent() {
     audioProcessor.midiEnabled->removeListener(this);
 }
 
+void SettingsComponent::resetLayoutToDefault() {
+    constexpr double defaultVisualiserSize = -0.25;
+    mainLayout.setItemLayout(0, -0.1, -0.5, defaultVisualiserSize);
+    mainLayout.setItemLayout(1, pluginEditor.RESIZER_BAR_SIZE, pluginEditor.RESIZER_BAR_SIZE, pluginEditor.RESIZER_BAR_SIZE);
+    mainLayout.setItemLayout(2, -0.1, -0.9, -(1.0 + defaultVisualiserSize));
+    audioProcessor.setProperty("mainLayoutVisSize", defaultVisualiserSize);
+
+#if OSCI_PREMIUM
+    modPanelCollapsed = true;
+    modPanelHeight = kCollapsedModHeight;
+    audioProcessor.setProperty("mainLayoutModSize", -0.35);
+#endif
+
+    resized();
+}
+
 void SettingsComponent::parameterValueChanged(int parameterIndex, float newValue) {
     auto safeThis = juce::Component::SafePointer<SettingsComponent>(this);
     bool midiJustEnabled = (parameterIndex == audioProcessor.midiEnabled->getParameterIndex()

--- a/Source/components/panels/SettingsComponent.h
+++ b/Source/components/panels/SettingsComponent.h
@@ -38,6 +38,7 @@ public:
     // Show or hide the example files grid panel on the right-hand side
     void showExamples(bool shouldShow);
     void changeListenerCallback(juce::ChangeBroadcaster* source) override;
+    void resetLayoutToDefault();
 
 private:
     OscirenderAudioProcessor& audioProcessor;

--- a/Source/video/FFmpegEncoderManager.cpp
+++ b/Source/video/FFmpegEncoderManager.cpp
@@ -31,6 +31,58 @@ juce::String FFmpegEncoderManager::buildVideoEncodingCommand(
     }
 }
 
+bool FFmpegEncoderManager::muxAudioAndVideo(const juce::File& videoInput, const juce::File& audioInput, const juce::File& output,
+                                            const juce::StringArray& audioCodecArgs, juce::String& error, const std::atomic<bool>* cancelRequested) const {
+    error.clear();
+    if (!ffmpegExecutable.existsAsFile()) {
+        error = "FFmpeg executable not found.";
+        return false;
+    }
+    if (!videoInput.existsAsFile()) {
+        error = "Temporary video file was not created.";
+        return false;
+    }
+    if (!audioInput.existsAsFile()) {
+        error = "Input audio file not found.";
+        return false;
+    }
+    if (output.existsAsFile() && !output.deleteFile()) {
+        error = "Could not replace output file.";
+        return false;
+    }
+
+    juce::StringArray command { ffmpegExecutable.getFullPathName(),
+                                "-hide_banner", "-loglevel", "error",
+                                "-i", videoInput.getFullPathName(),
+                                "-i", audioInput.getFullPathName(),
+                                "-c:v", "copy" };
+    command.addArray(audioCodecArgs);
+    command.addArray({ "-shortest", "-y", output.getFullPathName() });
+
+    juce::ChildProcess process;
+    if (!process.start(command, juce::ChildProcess::wantStdOut | juce::ChildProcess::wantStdErr)) {
+        error = "Failed to start FFmpeg for audio mux.";
+        return false;
+    }
+
+    while (process.isRunning()) {
+        if ((cancelRequested != nullptr && cancelRequested->load()) || juce::Thread::currentThreadShouldExit()) {
+            process.kill();
+            error = "Cancelled.";
+            return false;
+        }
+        process.waitForProcessToFinish(200);
+    }
+
+    const juce::String processOutput = process.readAllProcessOutput();
+    const bool succeeded = process.getExitCode() == 0 && output.existsAsFile() && output.getSize() > 0;
+    if (!succeeded) {
+        output.deleteFile();
+        error = processOutput.isNotEmpty() ? processOutput : "FFmpeg mux failed.";
+    }
+    return succeeded;
+}
+
 int FFmpegEncoderManager::estimateBitrateForVideotoolbox(int width, int height, double frameRate, int crfValue) {
     // Heuristic to estimate bitrate from CRF, resolution, and frame rate.
     // CRF values typically range from 0 (lossless) to 51 (worst quality).

--- a/Source/video/FFmpegEncoderManager.h
+++ b/Source/video/FFmpegEncoderManager.h
@@ -26,6 +26,9 @@ public:
         const juce::String& compressionPreset,
         const juce::File& outputFile);
 
+    bool muxAudioAndVideo(const juce::File& videoInput, const juce::File& audioInput, const juce::File& output,
+                          const juce::StringArray& audioCodecArgs, juce::String& error, const std::atomic<bool>* cancelRequested = nullptr) const;
+
     // Get available encoders for a given codec
     juce::Array<EncoderDetails> getAvailableEncodersForCodec(VideoCodec codec);
 

--- a/Source/visualiser/OfflineAudioToVideoRenderer.cpp
+++ b/Source/visualiser/OfflineAudioToVideoRenderer.cpp
@@ -55,80 +55,6 @@ juce::String durationSummary(double seconds) {
 
 }
 
-bool OfflineAudioToVideoRendererComponent::runFfmpegMux(const juce::File& ffmpegExe,
-                                                       const juce::File& videoInput,
-                                                       const juce::File& audioInput,
-                                                       const juce::File& output,
-                                                       const juce::StringArray& audioCodecArgs,
-                                                       const std::atomic<bool>& cancelRequested,
-                                                       juce::String& outError)
-{
-    if (!ffmpegExe.existsAsFile())
-    {
-        outError = "FFmpeg executable not found.";
-        return false;
-    }
-
-    if (!videoInput.existsAsFile())
-    {
-        outError = "Temporary video file was not created.";
-        return false;
-    }
-
-    if (!audioInput.existsAsFile())
-    {
-        outError = "Input audio file not found.";
-        return false;
-    }
-
-    juce::StringArray args;
-    args.add(ffmpegExe.getFullPathName());
-    args.addArray({"-hide_banner", "-loglevel", "error"});
-    args.addArray({"-i", videoInput.getFullPathName()});
-    args.addArray({"-i", audioInput.getFullPathName()});
-    args.addArray({"-c:v", "copy"});
-    args.addArray(audioCodecArgs);
-    args.addArray({"-shortest"});
-    args.addArray({"-y", output.getFullPathName()});
-
-    juce::ChildProcess process;
-    if (!process.start(args, juce::ChildProcess::wantStdOut | juce::ChildProcess::wantStdErr))
-    {
-        outError = "Failed to start FFmpeg for audio mux.";
-        return false;
-    }
-
-    // Wait until completion, but allow cancellation.
-    while (process.isRunning())
-    {
-        if (cancelRequested.load() || juce::Thread::currentThreadShouldExit())
-        {
-            process.kill();
-            outError = "Cancelled.";
-            return false;
-        }
-
-        process.waitForProcessToFinish(200);
-    }
-
-    const juce::String ffmpegOutput = process.readAllProcessOutput();
-
-    // ChildProcess doesn't reliably expose an exit code across platforms; treat missing output file as failure.
-    if (!output.existsAsFile())
-    {
-        outError = ffmpegOutput.isNotEmpty() ? ffmpegOutput : "FFmpeg mux failed.";
-        return false;
-    }
-
-    if (ffmpegOutput.isNotEmpty())
-    {
-        // Sometimes ffmpeg prints warnings; keep it concise.
-        outError = ffmpegOutput;
-    }
-
-    return true;
-}
-
 OfflineAudioToVideoRendererComponent::OfflinePreviewRenderer::OfflinePreviewRenderer(
     VisualiserParameters& parameters,
     osci::AudioBackgroundThreadManager& manager,
@@ -684,7 +610,7 @@ OfflineAudioToVideoRendererComponent::Result OfflineAudioToVideoRendererComponen
         juce::String muxError;
         const auto audioCodecArgs = recordingSettings.getAudioCodecArgs();
         offlineRenderLog.event("muxing audio into final video: audioCodecArgs=" + audioCodecArgs.joinIntoString(" "));
-        if (!runFfmpegMux(ffmpegFile, tempVideoFile, inputAudioFile, tempFinal.getFile(), audioCodecArgs, cancelRequested, muxError))
+        if (!ffmpegEncoderManager.muxAudioAndVideo(tempVideoFile, inputAudioFile, tempFinal.getFile(), audioCodecArgs, muxError, &cancelRequested))
         {
             tempFinal.getFile().deleteFile();
             tempVideoFile.deleteFile();

--- a/Source/visualiser/OfflineAudioToVideoRenderer.h
+++ b/Source/visualiser/OfflineAudioToVideoRenderer.h
@@ -44,14 +44,6 @@ public:
     void setOnFinished(FinishedCallback cb) { onFinished = std::move(cb); }
 
 private:
-    static bool runFfmpegMux(const juce::File& ffmpegExe,
-                             const juce::File& videoInput,
-                             const juce::File& audioInput,
-                             const juce::File& output,
-                             const juce::StringArray& audioCodecArgs,
-                             const std::atomic<bool>& cancelRequested,
-                             juce::String& outError);
-
     class OfflinePreviewRenderer : public VisualiserRenderer
     {
     public:

--- a/Source/visualiser/VisualiserComponent.cpp
+++ b/Source/visualiser/VisualiserComponent.cpp
@@ -503,7 +503,9 @@ void VisualiserComponent::setRecording(bool recording) {
         audioRecorder.stop();
         juce::String extension = "wav";
 #endif
-        chooser = std::make_unique<juce::FileChooser>("Save recording", audioProcessor.getLastOpenedDirectory(), "*." + extension);
+        const auto timestamp = juce::Time::getCurrentTime().formatted("%Y-%m-%d_%H-%M-%S");
+        const auto suggestedFile = audioProcessor.getLastOpenedDirectory().getChildFile(editor.appName + "_" + timestamp + "." + extension);
+        chooser = std::make_unique<juce::FileChooser>("Save recording", suggestedFile, "*." + extension);
         auto flags = juce::FileBrowserComponent::saveMode | juce::FileBrowserComponent::canSelectFiles | juce::FileBrowserComponent::warnAboutOverwriting;
 
 #if OSCI_PREMIUM
@@ -528,6 +530,7 @@ void VisualiserComponent::setRecording(bool recording) {
                     tempVideoFile->getFile().copyFileTo(file);
                 }
                 audioProcessor.setLastOpenedDirectory(file.getParentDirectory());
+                audioProcessor.recordingExportCompleted(file);
             } });
 #else
         chooser->launchAsync(flags, [this, extension](const juce::FileChooser &chooser) {
@@ -540,6 +543,7 @@ void VisualiserComponent::setRecording(bool recording) {
 
                 tempAudioFile->getFile().copyFileTo(file);
                 audioProcessor.setLastOpenedDirectory(file.getParentDirectory());
+                audioProcessor.recordingExportCompleted(file);
             } });
 #endif
     }

--- a/Source/visualiser/VisualiserComponent.cpp
+++ b/Source/visualiser/VisualiserComponent.cpp
@@ -667,7 +667,7 @@ void VisualiserComponent::popoutWindow() {
     child = visualiser;
     childUpdated();
     visualiser->setSize(350, 350);
-    const auto windowTitle = editor.appName == "sosci" ? "sosci Software Oscilloscope" : "Software Oscilloscope";
+    const auto windowTitle = editor.appName == "sosci" ? "sosci - Software Oscilloscope" : "Software Oscilloscope";
     popout = std::make_unique<VisualiserWindow>(windowTitle, this, isPopoutAlwaysOnTop());
     popout->setContentOwned(visualiser, true);
     popout->setUsingNativeTitleBar(true);

--- a/Source/visualiser/VisualiserComponent.cpp
+++ b/Source/visualiser/VisualiserComponent.cpp
@@ -697,7 +697,7 @@ void VisualiserComponent::popoutWindow() {
     child = visualiser;
     childUpdated();
     visualiser->setSize(350, 350);
-    const auto windowTitle = editor.appName == "sosci" ? "sosci - Software Oscilloscope" : "Software Oscilloscope";
+    const auto windowTitle = editor.appName + " - Software Oscilloscope";
     popout = std::make_unique<VisualiserWindow>(windowTitle, this, isPopoutAlwaysOnTop());
     popout->setContentOwned(visualiser, true);
     popout->setUsingNativeTitleBar(true);

--- a/Source/visualiser/VisualiserComponent.cpp
+++ b/Source/visualiser/VisualiserComponent.cpp
@@ -86,14 +86,6 @@ VisualiserComponent::VisualiserComponent(
         addAndMakeVisible(popOutButton);
         popOutButton.setTooltip("Opens the oscilloscope in a new window.");
     }
-    if (parent != nullptr) {
-        addAndMakeVisible(pinButton);
-        pinButton.setTooltip("Keep the popout window always on top.");
-        pinButton.setToggleState(parent->isPopoutAlwaysOnTop(), juce::NotificationType::dontSendNotification);
-        pinButton.onClick = [this] {
-            this->parent->setPopoutAlwaysOnTop(pinButton.getToggleState());
-        };
-    }
 #endif
     addAndMakeVisible(settingsButton);
     settingsButton.setTooltip("Opens the visualiser settings window.");
@@ -595,19 +587,12 @@ void VisualiserComponent::resized() {
         buttonRow = area.removeFromBottom(0);
         fullScreenButton.setVisible(false);
         popOutButton.setVisible(false);
-        pinButton.setVisible(false);
         settingsButton.setVisible(false);
         audioInputButton.setVisible(false);
         textureOutputButton.setVisible(false);
         record.setVisible(false);
         stopwatch.setVisible(false);
         timeline.setVisible(false);
-#if OSCI_PREMIUM
-        if (parent != nullptr) {
-            pinButton.setVisible(true);
-            pinButton.setBounds(getLocalBounds().removeFromBottom(25).removeFromRight(30));
-        }
-#endif
         overlayFadeCover.setBounds(getLocalBounds());
         overlayFadeCover.toFront(false);
         setViewportArea(area);
@@ -621,10 +606,6 @@ void VisualiserComponent::resized() {
         fullScreenButton.setBounds(buttons.removeFromRight(30));
     }
 #if OSCI_PREMIUM
-    if (parent != nullptr) {
-        pinButton.setVisible(true);
-        pinButton.setBounds(buttons.removeFromRight(30));
-    }
     if (child == nullptr && parent == nullptr) {
         popOutButton.setVisible(true);
         popOutButton.setBounds(buttons.removeFromRight(30));
@@ -741,9 +722,6 @@ void VisualiserComponent::setPopoutAlwaysOnTop(bool alwaysOnTop) {
     audioProcessor.globalSettings.save();
     if (popout != nullptr) {
         popout->setPinned(alwaysOnTop);
-    }
-    if (child != nullptr) {
-        child->pinButton.setToggleState(alwaysOnTop, juce::NotificationType::dontSendNotification);
     }
 }
 

--- a/Source/visualiser/VisualiserComponent.cpp
+++ b/Source/visualiser/VisualiserComponent.cpp
@@ -521,25 +521,10 @@ void VisualiserComponent::setRecording(bool recording) {
 
                 bool saved = false;
                 if (wasRecordingAudio && wasRecordingVideo) {
-                    // delete the file if it exists
-                    if (file.existsAsFile() && !file.deleteFile()) {
-                        osci::showOverlayMessage(*this, "Save Recording Failed", "Could not replace:\n" + file.getFullPathName());
-                        return;
-                    }
-                    juce::StringArray args;
-                    args.add(ffmpegFile.getFullPathName());
-                    args.addArray({"-i", tempVideoFile->getFile().getFullPathName(), "-i", tempAudioFile->getFile().getFullPathName(), "-c:v", "copy"});
-                    args.addArray(recordingSettings.getAudioCodecArgs());
-                    args.addArray({"-y", file.getFullPathName()});
-                    juce::ChildProcess muxProcess;
-                    saved = muxProcess.start(args, juce::ChildProcess::wantStdOut | juce::ChildProcess::wantStdErr);
-                    if (saved) {
-                        const auto processOutput = muxProcess.readAllProcessOutput();
-                        saved = muxProcess.waitForProcessToFinish(-1) && muxProcess.getExitCode() == 0
-                             && file.existsAsFile() && file.getSize() > 0;
-                        if (!saved && processOutput.isNotEmpty()) {
-                            juce::Logger::writeToLog("Recording mux failed: " + processOutput.substring(0, 500));
-                        }
+                    juce::String muxError;
+                    saved = ffmpegEncoderManager.muxAudioAndVideo(tempVideoFile->getFile(), tempAudioFile->getFile(), file, recordingSettings.getAudioCodecArgs(), muxError);
+                    if (!saved && muxError.isNotEmpty()) {
+                        juce::Logger::writeToLog("Recording mux failed: " + muxError.substring(0, 500));
                     }
                 } else if (wasRecordingAudio) {
                     saved = tempAudioFile->getFile().copyFileTo(file);

--- a/Source/visualiser/VisualiserComponent.cpp
+++ b/Source/visualiser/VisualiserComponent.cpp
@@ -86,6 +86,14 @@ VisualiserComponent::VisualiserComponent(
         addAndMakeVisible(popOutButton);
         popOutButton.setTooltip("Opens the oscilloscope in a new window.");
     }
+    if (parent != nullptr) {
+        addAndMakeVisible(pinButton);
+        pinButton.setTooltip("Keep the popout window always on top.");
+        pinButton.setToggleState(parent->isPopoutAlwaysOnTop(), juce::NotificationType::dontSendNotification);
+        pinButton.onClick = [this] {
+            this->parent->setPopoutAlwaysOnTop(pinButton.getToggleState());
+        };
+    }
 #endif
     addAndMakeVisible(settingsButton);
     settingsButton.setTooltip("Opens the visualiser settings window.");
@@ -563,6 +571,7 @@ void VisualiserComponent::resized() {
         buttonRow = area.removeFromBottom(0);
         fullScreenButton.setVisible(false);
         popOutButton.setVisible(false);
+        pinButton.setVisible(false);
         settingsButton.setVisible(false);
         audioInputButton.setVisible(false);
         textureOutputButton.setVisible(false);
@@ -582,6 +591,10 @@ void VisualiserComponent::resized() {
         fullScreenButton.setBounds(buttons.removeFromRight(30));
     }
 #if OSCI_PREMIUM
+    if (parent != nullptr) {
+        pinButton.setVisible(true);
+        pinButton.setBounds(buttons.removeFromRight(30));
+    }
     if (child == nullptr && parent == nullptr) {
         popOutButton.setVisible(true);
         popOutButton.setBounds(buttons.removeFromRight(30));
@@ -654,7 +667,8 @@ void VisualiserComponent::popoutWindow() {
     child = visualiser;
     childUpdated();
     visualiser->setSize(350, 350);
-    popout = std::make_unique<VisualiserWindow>("Software Oscilloscope", this);
+    const auto windowTitle = editor.appName == "sosci" ? "sosci Software Oscilloscope" : "Software Oscilloscope";
+    popout = std::make_unique<VisualiserWindow>(windowTitle, this, isPopoutAlwaysOnTop());
     popout->setContentOwned(visualiser, true);
     popout->setUsingNativeTitleBar(true);
     popout->setResizable(true, false);
@@ -690,6 +704,21 @@ void VisualiserComponent::childUpdated() {
             setRecording(false);
         };
     }
+}
+
+void VisualiserComponent::setPopoutAlwaysOnTop(bool alwaysOnTop) {
+    audioProcessor.globalSettings.set("popoutAlwaysOnTop", alwaysOnTop);
+    audioProcessor.globalSettings.save();
+    if (popout != nullptr) {
+        popout->setPinned(alwaysOnTop);
+    }
+    if (child != nullptr) {
+        child->pinButton.setToggleState(alwaysOnTop, juce::NotificationType::dontSendNotification);
+    }
+}
+
+bool VisualiserComponent::isPopoutAlwaysOnTop() const {
+    return audioProcessor.globalSettings.getBool("popoutAlwaysOnTop", true);
 }
 
 void VisualiserComponent::prepareOverlayFadeIn() {

--- a/Source/visualiser/VisualiserComponent.cpp
+++ b/Source/visualiser/VisualiserComponent.cpp
@@ -338,7 +338,9 @@ void VisualiserComponent::mouseMove(const juce::MouseEvent &event) {
                         // Check both fullscreen or pop-out mode
                         if (timerId == newTimerId && (fullScreen || this->parent != nullptr)) {
                             hideButtonRow = true;
-                            setMouseCursor(juce::MouseCursor::NoCursor);
+                            if (fullScreen) {
+                                setMouseCursor(juce::MouseCursor::NoCursor);
+                            }
                             resized();
                         }
                     }
@@ -525,17 +527,36 @@ void VisualiserComponent::setRecording(bool recording) {
                     file = file.withFileExtension(extension);
                 }
 
+                bool saved = false;
                 if (wasRecordingAudio && wasRecordingVideo) {
                     // delete the file if it exists
-                    if (file.existsAsFile()) {
-                        file.deleteFile();
+                    if (file.existsAsFile() && !file.deleteFile()) {
+                        osci::showOverlayMessage(*this, "Save Recording Failed", "Could not replace:\n" + file.getFullPathName());
+                        return;
                     }
-                    ffmpegProcess.start("\"" + ffmpegFile.getFullPathName() + "\" -i \"" + tempVideoFile->getFile().getFullPathName() + "\" -i \"" + tempAudioFile->getFile().getFullPathName() + "\" -c:v copy " + recordingSettings.getAudioCodecArgs().joinIntoString(" ") + " -y \"" + file.getFullPathName() + "\"");
-                    ffmpegProcess.close();
+                    juce::StringArray args;
+                    args.add(ffmpegFile.getFullPathName());
+                    args.addArray({"-i", tempVideoFile->getFile().getFullPathName(), "-i", tempAudioFile->getFile().getFullPathName(), "-c:v", "copy"});
+                    args.addArray(recordingSettings.getAudioCodecArgs());
+                    args.addArray({"-y", file.getFullPathName()});
+                    juce::ChildProcess muxProcess;
+                    saved = muxProcess.start(args, juce::ChildProcess::wantStdOut | juce::ChildProcess::wantStdErr);
+                    if (saved) {
+                        const auto processOutput = muxProcess.readAllProcessOutput();
+                        saved = muxProcess.waitForProcessToFinish(-1) && muxProcess.getExitCode() == 0
+                             && file.existsAsFile() && file.getSize() > 0;
+                        if (!saved && processOutput.isNotEmpty()) {
+                            juce::Logger::writeToLog("Recording mux failed: " + processOutput.substring(0, 500));
+                        }
+                    }
                 } else if (wasRecordingAudio) {
-                    tempAudioFile->getFile().copyFileTo(file);
+                    saved = tempAudioFile->getFile().copyFileTo(file);
                 } else if (wasRecordingVideo) {
-                    tempVideoFile->getFile().copyFileTo(file);
+                    saved = tempVideoFile->getFile().copyFileTo(file);
+                }
+                if (!saved) {
+                    osci::showOverlayMessage(*this, "Save Recording Failed", "Could not write:\n" + file.getFullPathName());
+                    return;
                 }
                 audioProcessor.setLastOpenedDirectory(file.getParentDirectory());
                 audioProcessor.recordingExportCompleted(file);
@@ -549,7 +570,10 @@ void VisualiserComponent::setRecording(bool recording) {
                     file = file.withFileExtension(extension);
                 }
 
-                tempAudioFile->getFile().copyFileTo(file);
+                if (!tempAudioFile->getFile().copyFileTo(file)) {
+                    osci::showOverlayMessage(*this, "Save Recording Failed", "Could not write:\n" + file.getFullPathName());
+                    return;
+                }
                 audioProcessor.setLastOpenedDirectory(file.getParentDirectory());
                 audioProcessor.recordingExportCompleted(file);
             } });
@@ -578,6 +602,12 @@ void VisualiserComponent::resized() {
         record.setVisible(false);
         stopwatch.setVisible(false);
         timeline.setVisible(false);
+#if OSCI_PREMIUM
+        if (parent != nullptr) {
+            pinButton.setVisible(true);
+            pinButton.setBounds(getLocalBounds().removeFromBottom(25).removeFromRight(30));
+        }
+#endif
         overlayFadeCover.setBounds(getLocalBounds());
         overlayFadeCover.toFront(false);
         setViewportArea(area);

--- a/Source/visualiser/VisualiserComponent.h
+++ b/Source/visualiser/VisualiserComponent.h
@@ -109,7 +109,6 @@ private:
 
     osci::SvgButton fullScreenButton{"fullScreen", BinaryData::fullscreen_svg, juce::Colours::white, juce::Colours::white};
     osci::SvgButton popOutButton{"popOut", BinaryData::open_in_new_svg, juce::Colours::white, juce::Colours::white};
-    osci::SvgButton pinButton{"pin", BinaryData::push_pin_svg, osci::Colours::textMuted(), osci::Colours::accentColor()};
     osci::SvgButton settingsButton{"settings", BinaryData::cog_svg, juce::Colours::white, juce::Colours::white};
     osci::SvgButton audioInputButton{"audioInput", BinaryData::microphone_svg, juce::Colours::white, juce::Colours::red};
     osci::SvgButton textureOutputButton{"textureOutput", BinaryData::spout_svg, juce::Colours::white, juce::Colours::red};

--- a/Source/visualiser/VisualiserComponent.h
+++ b/Source/visualiser/VisualiserComponent.h
@@ -55,6 +55,8 @@ public:
     bool keyPressed(const juce::KeyPress& key) override;
     void setRecording(bool recording);
     void childUpdated();
+    void setPopoutAlwaysOnTop(bool alwaysOnTop);
+    bool isPopoutAlwaysOnTop() const;
     void prepareOverlayFadeIn();
     void fadeInAfterOverlay();
     void cancelOverlayFadeIn();
@@ -107,6 +109,7 @@ private:
 
     osci::SvgButton fullScreenButton{"fullScreen", BinaryData::fullscreen_svg, juce::Colours::white, juce::Colours::white};
     osci::SvgButton popOutButton{"popOut", BinaryData::open_in_new_svg, juce::Colours::white, juce::Colours::white};
+    osci::SvgButton pinButton{"pin", BinaryData::push_pin_svg, osci::Colours::textMuted(), osci::Colours::accentColor()};
     osci::SvgButton settingsButton{"settings", BinaryData::cog_svg, juce::Colours::white, juce::Colours::white};
     osci::SvgButton audioInputButton{"audioInput", BinaryData::microphone_svg, juce::Colours::white, juce::Colours::red};
     osci::SvgButton textureOutputButton{"textureOutput", BinaryData::spout_svg, juce::Colours::white, juce::Colours::red};
@@ -157,8 +160,8 @@ private:
 
 class VisualiserWindow : public juce::DocumentWindow {
 public:
-    VisualiserWindow(juce::String name, VisualiserComponent* parent) : parent(parent), juce::DocumentWindow(name, juce::Colours::black, juce::DocumentWindow::TitleBarButtons::allButtons) {
-        setAlwaysOnTop(true);
+    VisualiserWindow(juce::String name, VisualiserComponent* parent, bool pinned) : juce::DocumentWindow(name, juce::Colours::black, juce::DocumentWindow::TitleBarButtons::allButtons), parent(parent), pinned(pinned) {
+        setAlwaysOnTop(pinned);
     }
 
     void closeButtonPressed() override {
@@ -175,7 +178,7 @@ public:
 
     void toggleFullScreen() {
         isFullScreen = !isFullScreen;
-        setAlwaysOnTop(!isFullScreen);
+        setAlwaysOnTop(!isFullScreen && pinned);
 #if JUCE_WINDOWS
         if (isFullScreen) {
             windowedBounds = getBounds();
@@ -196,9 +199,14 @@ public:
     }
 
     bool getIsFullScreen() const { return isFullScreen; }
+    void setPinned(bool shouldBePinned) {
+        pinned = shouldBePinned;
+        setAlwaysOnTop(!isFullScreen && pinned);
+    }
 
 private:
     VisualiserComponent* parent;
     bool isFullScreen = false;
+    bool pinned = true;
     juce::Rectangle<int> windowedBounds;
 };

--- a/Source/visualiser/VisualiserSettings.cpp
+++ b/Source/visualiser/VisualiserSettings.cpp
@@ -5,28 +5,80 @@
 #include "../PluginProcessor.h"
 #endif
 
+namespace {
+constexpr int outerHorizontalPadding = 20;
+constexpr int outerVerticalPadding = 10;
+constexpr int sectionGap = 8;
+constexpr int controlRowHeight = 30;
+constexpr int displayHorizontalPadding = 10;
+constexpr int displayBottomPadding = 7;
+constexpr int overlayLabelWidth = 120;
+constexpr int overlayControlGap = 8;
+constexpr int toggleGridTopGap = 8;
+constexpr int sweepHorizontalPadding = 12;
+constexpr int sweepHeaderPaintedHeight = 30;
+constexpr int sweepToggleWidth = 30;
+constexpr int sweepToggleHeight = 24;
+constexpr int sweepTitleGap = 6;
+constexpr int sweepControlGap = 4;
+constexpr int sweepSelectorTopGap = 10;
+constexpr int selectorLabelHeight = 18;
+constexpr int selectorLabelGap = 4;
+constexpr int selectorControlHeight = 32;
+constexpr int selectorRowGap = 10;
+constexpr int selectorColumnGap = 12;
+constexpr int twoColumnMinimumWidth = 400;
+constexpr int sweepBottomPadding = 10;
+constexpr int upgradeButtonHeight = 36;
+
+constexpr int selectorHeight = selectorLabelHeight + selectorLabelGap + selectorControlHeight;
+}
+
 VisualiserSettings::VisualiserSettings(VisualiserParameters& p, int numChannels, RecordingParameters& recordingParameters)
     : parameters(p), recordingParameters(recordingParameters), numChannels(numChannels) {
+    addAndMakeVisible(displayOptions);
     addAndMakeVisible(lineColour);
     addAndMakeVisible(lightEffects);
     addAndMakeVisible(videoEffects);
     addAndMakeVisible(lineEffects);
-    addAndMakeVisible(sweepMs);
-    addAndMakeVisible(triggerValue);
-#if OSCI_GUI_ENABLE_CHOWDSP_RESAMPLING
-    addAndMakeVisible(upsamplingToggle);
-#endif
-    addAndMakeVisible(sweepToggle);
-    addAndMakeVisible(screenOverlayLabel);
-    addAndMakeVisible(screenOverlay);
+    addAndMakeVisible(sweepSettings);
+    lineColourSwatch = std::make_shared<osci::ColourSwatchComponent>([this] { return getCurrentLineColour(); }, "Current line colour");
+    lineColour.getEffect(0)->setComponent(lineColourSwatch);
+
+    displayOptions.addAndMakeVisible(screenOverlayLabel);
+    displayOptions.addAndMakeVisible(screenOverlay);
+    displayOptions.addAndMakeVisible(optionToggleGrid);
+    optionToggleGrid.setUseViewport(false);
+    optionToggleGrid.setMinItemWidth(135);
+    optionToggleGrid.setItemHeight(36);
+    optionToggleGrid.setItemMargin(3);
+    sweepSettings.addAndMakeVisible(sweepToggle);
+    sweepSettings.addAndMakeVisible(sweepTitle);
+    sweepSettings.addAndMakeVisible(sweepMs);
+    sweepSettings.addAndMakeVisible(triggerValue);
+    sweepSettings.addAndMakeVisible(triggerSourceLabel);
+    sweepSettings.addAndMakeVisible(triggerSourceBox);
+    sweepSettings.addAndMakeVisible(triggerSlopeLabel);
+    sweepSettings.addAndMakeVisible(triggerSlopeBox);
+    sweepTitle.setFont(juce::Font{juce::FontOptions{15.0f}});
+    sweepTitle.setColour(juce::Label::textColourId, osci::Colours::text());
+    sweepTitle.setJustificationType(juce::Justification::centredLeft);
+    sweepTitle.setInterceptsMouseClicks(false, false);
+    triggerSourceLabel.setFont(juce::Font{juce::FontOptions{14.0f}});
+    triggerSlopeLabel.setFont(juce::Font{juce::FontOptions{14.0f}});
+    triggerSourceLabel.setColour(juce::Label::textColourId, osci::Colours::text());
+    triggerSlopeLabel.setColour(juce::Label::textColourId, osci::Colours::text());
 #if OSCI_PREMIUM
     addAndMakeVisible(scale);
     addAndMakeVisible(position);
     addAndMakeVisible(screenColour);
-    addAndMakeVisible(flipVerticalToggle);
-    addAndMakeVisible(flipHorizontalToggle);
-    addAndMakeVisible(goniometerToggle);
-    addAndMakeVisible(shutterSyncToggle);
+    optionToggleGrid.addItem(flipVerticalToggle);
+    optionToggleGrid.addItem(flipHorizontalToggle);
+    optionToggleGrid.addItem(goniometerToggle);
+    optionToggleGrid.addItem(shutterSyncToggle);
+#endif
+#if OSCI_GUI_ENABLE_CHOWDSP_RESAMPLING
+    optionToggleGrid.addItem(upsamplingToggle);
 #endif
 #if !OSCI_PREMIUM
     addAndMakeVisible(upgradeButton);
@@ -47,18 +99,26 @@ VisualiserSettings::VisualiserSettings(VisualiserParameters& p, int numChannels,
         parameters.screenOverlay->setUnnormalisedValueNotifyingHost(screenOverlay.getSelectedId());
     };
 
-    sweepMs.setEnabled(sweepToggle.getToggleState());
-    triggerValue.setEnabled(sweepToggle.getToggleState());
+    triggerSourceBox.addItem("Left", 1);
+    triggerSourceBox.addItem("Right", 2);
+    triggerSourceBox.onChange = [this] {
+        parameters.triggerSource->setUnnormalisedValueNotifyingHost(triggerSourceBox.getSelectedId() - 1);
+    };
+    triggerSlopeBox.addItem("Rising", 1);
+    triggerSlopeBox.addItem("Falling", 2);
+    triggerSlopeBox.onChange = [this] {
+        parameters.triggerSlope->setUnnormalisedValueNotifyingHost(triggerSlopeBox.getSelectedId() - 1);
+    };
+
+    sweepMs.setEnabled(parameters.sweepEnabled->getBoolValue());
+    updateTriggerControls();
 
     sweepMs.slider.setSkewFactorFromMidPoint(100);
 
-    sweepToggle.onClick = [this] {
-        sweepMs.setEnabled(sweepToggle.getToggleState());
-        triggerValue.setEnabled(sweepToggle.getToggleState());
-        resized();
-    };
-
     parameters.screenOverlay->addListener(this);
+    parameters.sweepEnabled->addListener(this);
+    parameters.triggerSource->addListener(this);
+    parameters.triggerSlope->addListener(this);
     recordingParameters.canvasWidth.addListener(this);
     recordingParameters.canvasHeight.addListener(this);
     updateScreenOverlayItemsEnabled();
@@ -66,6 +126,9 @@ VisualiserSettings::VisualiserSettings(VisualiserParameters& p, int numChannels,
 
 VisualiserSettings::~VisualiserSettings() {
     parameters.screenOverlay->removeListener(this);
+    parameters.sweepEnabled->removeListener(this);
+    parameters.triggerSource->removeListener(this);
+    parameters.triggerSlope->removeListener(this);
     recordingParameters.canvasWidth.removeListener(this);
     recordingParameters.canvasHeight.removeListener(this);
 }
@@ -102,67 +165,173 @@ void VisualiserSettings::updateScreenOverlayItemsEnabled() {
     screenOverlay.setSelectedId(static_cast<int>(selectedOverlay), juce::dontSendNotification);
 }
 
+void VisualiserSettings::updateTriggerControls() {
+    const bool enabled = parameters.sweepEnabled->getBoolValue();
+    sweepMs.setEnabled(enabled);
+    triggerValue.setEnabled(enabled);
+    triggerSourceLabel.setEnabled(enabled);
+    triggerSourceBox.setEnabled(enabled);
+    triggerSlopeLabel.setEnabled(enabled);
+    triggerSlopeBox.setEnabled(enabled);
+    triggerSourceBox.setSelectedId(parameters.triggerSource->getValueUnnormalised() + 1, juce::dontSendNotification);
+    triggerSlopeBox.setSelectedId(parameters.triggerSlope->getValueUnnormalised() + 1, juce::dontSendNotification);
+}
+
+juce::Colour VisualiserSettings::getCurrentLineColour() const {
+    const auto hue = juce::jlimit(0.0f, 1.0f, parameters.hueEffect->getActualValue() / 360.0f);
+    const auto saturation = juce::jlimit(0.0f, 1.0f, parameters.lineSaturationEffect->getActualValue());
+    const auto intensityParameter = parameters.intensityEffect->parameters[0];
+    const auto intensity = juce::jmap(parameters.intensityEffect->getActualValue(), static_cast<float>(intensityParameter->min), static_cast<float>(intensityParameter->max), 0.0f, 1.0f);
+    return juce::Colour::fromHSV(hue, saturation, juce::jlimit(0.0f, 1.0f, intensity), 1.0f);
+}
+
+int VisualiserSettings::getDisplayOptionsHeight(int width) const {
+    const int gridWidth = juce::jmax(1, width - displayHorizontalPadding * 2);
+    const int gridHeight = optionToggleGrid.getNumItems() > 0 ? optionToggleGrid.calculateRequiredHeight(gridWidth) : 0;
+    return SettingsSection::headerHeight + controlRowHeight + (gridHeight > 0 ? toggleGridTopGap + gridHeight : 0) + displayBottomPadding;
+}
+
+int VisualiserSettings::getSweepSettingsHeight(int width) const {
+    const bool useTwoColumns = width >= twoColumnMinimumWidth;
+    const int fixedBodyHeight = controlRowHeight + sweepControlGap + controlRowHeight + sweepSelectorTopGap;
+    return SettingsSection::headerHeight + fixedBodyHeight + selectorHeight * (useTwoColumns ? 1 : 2)
+         + (useTwoColumns ? 0 : selectorRowGap) + sweepBottomPadding;
+}
+
+std::vector<VisualiserSettings::LayoutItem> VisualiserSettings::getLayoutItems(int sectionWidth) {
+    std::vector<LayoutItem> items;
+    items.reserve(10);
+    items.push_back({&displayOptions, getDisplayOptionsHeight(sectionWidth)});
+    items.push_back({&lineColour, lineColour.getPreferredHeight()});
+#if OSCI_PREMIUM
+    items.push_back({&screenColour, screenColour.getPreferredHeight()});
+#endif
+    items.push_back({&lightEffects, lightEffects.getPreferredHeight()});
+    items.push_back({&videoEffects, videoEffects.getPreferredHeight()});
+    items.push_back({&lineEffects, lineEffects.getPreferredHeight()});
+#if OSCI_PREMIUM
+    items.push_back({&scale, scale.getPreferredHeight()});
+    items.push_back({&position, position.getPreferredHeight()});
+#endif
+    items.push_back({&sweepSettings, getSweepSettingsHeight(sectionWidth)});
+#if !OSCI_PREMIUM
+    items.push_back({&upgradeButton, upgradeButtonHeight});
+#endif
+    return items;
+}
+
+int VisualiserSettings::getPreferredHeight(int width) {
+    const int sectionWidth = juce::jmax(1, width - outerHorizontalPadding * 2);
+    const auto items = getLayoutItems(sectionWidth);
+    int height = outerVerticalPadding * 2;
+    for (const auto& item : items) {
+        height += item.height;
+    }
+    if (items.size() > 1) {
+        height += (static_cast<int>(items.size()) - 1) * sectionGap;
+    }
+    return height;
+}
+
+void VisualiserSettings::setSizeToFitWidth(int width) {
+    const int contentWidth = juce::jmax(1, width);
+    setSize(contentWidth, getPreferredHeight(contentWidth));
+}
+
+void VisualiserSettings::fitToViewport(juce::Viewport& viewport) {
+    int contentWidth = juce::jmax(1, viewport.getWidth());
+    if (getPreferredHeight(contentWidth) > viewport.getHeight()) {
+        contentWidth = juce::jmax(1, contentWidth - viewport.getScrollBarThickness());
+    }
+    setSizeToFitWidth(contentWidth);
+}
+
+void VisualiserSettings::layoutDisplayOptions() {
+    auto area = displayOptions.getLocalBounds().reduced(displayHorizontalPadding, 0);
+    area.removeFromTop(SettingsSection::headerHeight);
+
+    auto overlayRow = area.removeFromTop(controlRowHeight);
+    overlayRow = overlayRow.withSizeKeepingCentre(juce::jmin(520, overlayRow.getWidth()), overlayRow.getHeight());
+    screenOverlayLabel.setBounds(overlayRow.removeFromLeft(overlayLabelWidth));
+    overlayRow.removeFromLeft(overlayControlGap);
+    screenOverlay.setBounds(overlayRow);
+
+    if (optionToggleGrid.getNumItems() == 0) {
+        return;
+    }
+
+    area.removeFromTop(toggleGridTopGap);
+    optionToggleGrid.setBounds(area.removeFromTop(optionToggleGrid.calculateRequiredHeight(area.getWidth())));
+}
+
+void VisualiserSettings::layoutSweepSettings() {
+    auto area = sweepSettings.getLocalBounds().reduced(sweepHorizontalPadding, 0);
+    auto header = area.removeFromTop(SettingsSection::headerHeight);
+    auto paintedHeader = header.removeFromTop(sweepHeaderPaintedHeight);
+    sweepToggle.setBounds(paintedHeader.removeFromLeft(sweepToggleWidth).withSizeKeepingCentre(sweepToggleWidth, sweepToggleHeight).translated(0, 1));
+    paintedHeader.removeFromLeft(sweepTitleGap);
+    sweepTitle.setBounds(paintedHeader);
+
+    sweepMs.setBounds(area.removeFromTop(controlRowHeight));
+    area.removeFromTop(sweepControlGap);
+    triggerValue.setBounds(area.removeFromTop(controlRowHeight));
+    area.removeFromTop(sweepSelectorTopGap);
+
+    auto layoutSelector = [](juce::Rectangle<int> selectorArea, juce::Label& label, juce::ComboBox& comboBox) {
+        label.setBounds(selectorArea.removeFromTop(selectorLabelHeight));
+        selectorArea.removeFromTop(selectorLabelGap);
+        comboBox.setBounds(selectorArea.removeFromTop(selectorControlHeight));
+    };
+
+    if (sweepSettings.getWidth() >= twoColumnMinimumWidth) {
+        auto selectors = area.removeFromTop(selectorHeight);
+        auto sourceArea = selectors.removeFromLeft((selectors.getWidth() - selectorColumnGap) / 2);
+        selectors.removeFromLeft(selectorColumnGap);
+        layoutSelector(sourceArea, triggerSourceLabel, triggerSourceBox);
+        layoutSelector(selectors, triggerSlopeLabel, triggerSlopeBox);
+    } else {
+        layoutSelector(area.removeFromTop(selectorHeight), triggerSourceLabel, triggerSourceBox);
+        area.removeFromTop(selectorRowGap);
+        layoutSelector(area.removeFromTop(selectorHeight), triggerSlopeLabel, triggerSlopeBox);
+    }
+}
+
 void VisualiserSettings::resized() {
-	auto area = getLocalBounds().reduced(20, 0).withTrimmedBottom(20);
-	double rowHeight = 30;
-
-    auto screenOverlayArea = area.removeFromTop(2 * rowHeight);
-    screenOverlayArea = screenOverlayArea.withSizeKeepingCentre(300, rowHeight);
-    screenOverlayLabel.setBounds(screenOverlayArea.removeFromLeft(120));
-    screenOverlay.setBounds(screenOverlayArea.removeFromRight(180));
-
-    lineColour.setBounds(area.removeFromTop(lineColour.getHeight()));
-#if OSCI_PREMIUM
-    area.removeFromTop(10);
-    screenColour.setBounds(area.removeFromTop(screenColour.getHeight()));
-#endif
-    area.removeFromTop(10);
-    lightEffects.setBounds(area.removeFromTop(lightEffects.getHeight()));
-    area.removeFromTop(10);
-    videoEffects.setBounds(area.removeFromTop(videoEffects.getHeight()));
-    area.removeFromTop(10);
-    lineEffects.setBounds(area.removeFromTop(lineEffects.getHeight()));
-
-#if OSCI_PREMIUM
-    area.removeFromTop(10);
-    scale.setBounds(area.removeFromTop(scale.getHeight()));
-    area.removeFromTop(10);
-    position.setBounds(area.removeFromTop(position.getHeight()));
-    area.removeFromTop(10);
-    flipVerticalToggle.setBounds(area.removeFromTop(rowHeight));
-    flipHorizontalToggle.setBounds(area.removeFromTop(rowHeight));
-    goniometerToggle.setBounds(area.removeFromTop(rowHeight));
-    shutterSyncToggle.setBounds(area.removeFromTop(rowHeight));
-#endif
-
+    auto area = getLocalBounds().reduced(outerHorizontalPadding, outerVerticalPadding);
+    const auto items = getLayoutItems(area.getWidth());
+    for (size_t index = 0; index < items.size(); ++index) {
+        auto itemArea = area.removeFromTop(items[index].height);
 #if !OSCI_PREMIUM
+        if (items[index].component == &upgradeButton) {
+            const int buttonWidth = juce::jlimit(180, 320, itemArea.getWidth());
+            itemArea = itemArea.withSizeKeepingCentre(buttonWidth, itemArea.getHeight());
+        }
 #endif
-#if OSCI_GUI_ENABLE_CHOWDSP_RESAMPLING
-    upsamplingToggle.setBounds(area.removeFromTop(rowHeight));
-#endif
-    sweepToggle.setBounds(area.removeFromTop(rowHeight));
-    sweepMs.setBounds(area.removeFromTop(rowHeight));
-    triggerValue.setBounds(area.removeFromTop(rowHeight));
-#if !OSCI_PREMIUM
-    area.removeFromTop(10);
-    const int buttonHeight = 36;
-    auto buttonArea = area.removeFromTop(buttonHeight);
-    auto buttonWidth = juce::jlimit(180, 320, buttonArea.getWidth());
-    upgradeButton.setBounds(buttonArea.withSizeKeepingCentre(buttonWidth, buttonHeight));
-#endif
+        items[index].component->setBounds(itemArea);
+        if (index + 1 < items.size()) {
+            area.removeFromTop(sectionGap);
+        }
+    }
+
+    layoutDisplayOptions();
+    layoutSweepSettings();
 }
 
 void VisualiserSettings::parameterValueChanged(int parameterIndex, float newValue) {
     juce::ignoreUnused(newValue);
 
     const bool screenOverlayChanged = parameterIndex == parameters.screenOverlay->getParameterIndex();
+    const bool triggerChanged = parameterIndex == parameters.triggerSource->getParameterIndex()
+                             || parameterIndex == parameters.triggerSlope->getParameterIndex()
+                             || parameterIndex == parameters.sweepEnabled->getParameterIndex();
     const bool canvasSizeChanged = parameterIndex == recordingParameters.canvasWidth.getParameterIndex()
                                 || parameterIndex == recordingParameters.canvasHeight.getParameterIndex();
 
-    if (screenOverlayChanged || canvasSizeChanged) {
+    if (screenOverlayChanged || canvasSizeChanged || triggerChanged) {
         juce::MessageManager::callAsync([safeThis = juce::Component::SafePointer<VisualiserSettings>(this)] {
             if (safeThis != nullptr) {
                 safeThis->updateScreenOverlayItemsEnabled();
+                safeThis->updateTriggerControls();
             }
         });
     }

--- a/Source/visualiser/VisualiserSettings.h
+++ b/Source/visualiser/VisualiserSettings.h
@@ -12,16 +12,27 @@ class OscirenderAudioProcessor;
 #endif
 class RecordingParameters;
 
-class GroupedSettings : public juce::GroupComponent {
+class SettingsSection : public juce::GroupComponent {
 public:
-    GroupedSettings(std::vector<std::shared_ptr<EffectComponent>> effects, juce::String label) : effects(effects), juce::GroupComponent(label, label) {
-        for (auto effect : effects) {
+    explicit SettingsSection(const juce::String& label) : juce::GroupComponent(label, label) {
+        const auto background = osci::Colours::darker().overlaidWith(juce::Colours::transparentBlack.withAlpha(0.2f));
+        setColour(osci::groupComponentBackgroundColourId, background);
+        setColour(osci::effectComponentBackgroundColourId, juce::Colours::transparentBlack);
+    }
+
+    static constexpr int headerHeight = 35;
+
+private:
+    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(SettingsSection)
+};
+
+class GroupedSettings : public SettingsSection {
+public:
+    GroupedSettings(std::vector<std::shared_ptr<EffectComponent>> effects, juce::String label)
+        : SettingsSection(label), effects(std::move(effects)) {
+        for (auto effect : this->effects) {
             addAndMakeVisible(effect.get());
         }
-
-        const auto effectRowColour = osci::Colours::darker().overlaidWith(juce::Colours::transparentBlack.withAlpha(0.2f));
-        setColour(osci::groupComponentBackgroundColourId, effectRowColour);
-        setColour(osci::effectComponentBackgroundColourId, juce::Colours::transparentBlack);
     }
 
 #ifndef SOSCI
@@ -33,19 +44,23 @@ public:
 
     void resized() override {
         auto area = getLocalBounds();
-        area.removeFromTop(35);
-        double rowHeight = 30;
-
+        area.removeFromTop(headerHeight);
         for (auto effect : effects) {
             effect->setBounds(area.removeFromTop(rowHeight));
         }
     }
 
-    int getHeight() {
-        return 40 + effects.size() * 30;
+    int getPreferredHeight() const {
+        return headerHeight + static_cast<int>(effects.size()) * rowHeight + bottomPadding;
+    }
+
+    std::shared_ptr<EffectComponent> getEffect(int index) const {
+        return effects[static_cast<size_t>(index)];
     }
 
 private:
+    static constexpr int rowHeight = 30;
+    static constexpr int bottomPadding = 5;
     std::vector<std::shared_ptr<EffectComponent>> effects;
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(GroupedSettings)
@@ -62,6 +77,9 @@ public:
 
     void paint(juce::Graphics& g) override;
     void resized() override;
+    int getPreferredHeight(int width);
+    void setSizeToFitWidth(int width);
+    void fitToViewport(juce::Viewport& viewport);
     void parameterValueChanged(int parameterIndex, float newValue) override;
     void parameterGestureChanged(int parameterIndex, bool gestureIsStarting) override;
 
@@ -71,7 +89,24 @@ public:
     std::function<void()> onUpgradeRequested;
 
 private:
+    struct LayoutItem {
+        juce::Component* component;
+        int height;
+    };
+
     void updateScreenOverlayItemsEnabled();
+    void updateTriggerControls();
+    juce::Colour getCurrentLineColour() const;
+    std::vector<LayoutItem> getLayoutItems(int sectionWidth);
+    int getDisplayOptionsHeight(int width) const;
+    int getSweepSettingsHeight(int width) const;
+    void layoutDisplayOptions();
+    void layoutSweepSettings();
+
+    SettingsSection displayOptions{"Display Options"};
+    SettingsSection sweepSettings{""};
+    juce::Label sweepTitle{"Sweep & Trigger", "Sweep & Trigger"};
+    osci::GridComponent optionToggleGrid{juce::FlexBox::JustifyContent::center};
 
     GroupedSettings lineColour{
         std::vector<std::shared_ptr<EffectComponent>>{
@@ -80,6 +115,7 @@ private:
             std::make_shared<EffectComponent>(*parameters.intensityEffect),
         },
         "Line Colour"};
+    std::shared_ptr<osci::ColourSwatchComponent> lineColourSwatch;
 
 #if OSCI_PREMIUM
     GroupedSettings screenColour{
@@ -122,14 +158,18 @@ private:
 
     EffectComponent sweepMs{*parameters.sweepMsEffect};
     EffectComponent triggerValue{*parameters.triggerValueEffect};
+    juce::Label triggerSourceLabel{"Trigger Source", "Trigger Source"};
+    juce::ComboBox triggerSourceBox;
+    juce::Label triggerSlopeLabel{"Trigger Slope", "Trigger Slope"};
+    juce::ComboBox triggerSlopeBox;
 
     juce::Label screenOverlayLabel{"Screen Overlay", "Screen Overlay"};
     juce::ComboBox screenOverlay;
 
 #if OSCI_GUI_ENABLE_CHOWDSP_RESAMPLING
-    jux::SwitchButton upsamplingToggle{parameters.upsamplingEnabled};
+    ToggleLabelComponent upsamplingToggle{parameters.upsamplingEnabled, {}, false};
 #endif
-    jux::SwitchButton sweepToggle{parameters.sweepEnabled};
+    jux::SwitchButton sweepToggle{parameters.sweepEnabled, true, false};
 
 #if OSCI_PREMIUM
     GroupedSettings scale{
@@ -146,10 +186,10 @@ private:
         },
         "Image Position"};
 
-    jux::SwitchButton flipVerticalToggle{parameters.flipVertical};
-    jux::SwitchButton flipHorizontalToggle{parameters.flipHorizontal};
-    jux::SwitchButton goniometerToggle{parameters.goniometer};
-    jux::SwitchButton shutterSyncToggle{parameters.shutterSync};
+    ToggleLabelComponent flipVerticalToggle{parameters.flipVertical, {}, false};
+    ToggleLabelComponent flipHorizontalToggle{parameters.flipHorizontal, {}, false};
+    ToggleLabelComponent goniometerToggle{parameters.goniometer, {}, false};
+    ToggleLabelComponent shutterSyncToggle{parameters.shutterSync, {}, false};
 #endif
 
 #if !OSCI_PREMIUM
@@ -161,7 +201,7 @@ private:
 
 class ScrollableComponent : public juce::Component {
 public:
-    ScrollableComponent(juce::Component& component) : component(component) {
+    ScrollableComponent(VisualiserSettings& component) : component(component) {
         addAndMakeVisible(viewport);
         viewport.setViewedComponent(&component, false);
         viewport.setScrollBarsShown(true, false, true, false);
@@ -173,19 +213,20 @@ public:
 
     void resized() override {
         viewport.setBounds(getLocalBounds());
+        component.fitToViewport(viewport);
     }
 
 private:
     juce::Viewport viewport;
-    juce::Component& component;
+    VisualiserSettings& component;
 };
 
 class SettingsWindow : public juce::DialogWindow {
 public:
-    SettingsWindow(juce::String name, juce::Component& component, int windowWidth, int windowHeight, int componentWidth, int componentHeight) : juce::DialogWindow(name, osci::Colours::darker(), true, true), component(component), componentHeight(componentHeight) {
-        setContentComponent(&viewport);
+    SettingsWindow(juce::String name, VisualiserSettings& component, int windowWidth, int windowHeight, int maximumWindowWidth) : juce::DialogWindow(name, osci::Colours::darker(), true, true), component(component) {
+        setContentNonOwned(&viewport, false);
         centreWithSize(windowWidth, windowHeight);
-        setResizeLimits(windowWidth, windowHeight, componentWidth, componentHeight);
+        setResizeLimits(windowWidth, windowHeight, maximumWindowWidth, juce::jmax(windowHeight, component.getPreferredHeight(windowWidth)));
         setResizable(true, false);
         viewport.setColour(juce::ScrollBar::trackColourId, juce::Colours::white);
         viewport.setViewedComponent(&component, false);
@@ -199,12 +240,10 @@ public:
 
     void resized() override {
         DialogWindow::resized();
-        // Update the component width to match the viewport width while maintaining its height
-        component.setSize(viewport.getWidth(), componentHeight);
+        component.fitToViewport(viewport);
     }
 
 private:
     juce::Viewport viewport;
-    juce::Component& component;
-    int componentHeight;
+    VisualiserSettings& component;
 };

--- a/osci-render.jucer
+++ b/osci-render.jucer
@@ -143,7 +143,6 @@
               file="Resources/svg/oscilloscope.svg"/>
         <FILE id="pStSvg" name="paste.svg" compile="0" resource="1" file="Resources/svg/paste.svg"/>
         <FILE id="f2D5tv" name="pause.svg" compile="0" resource="1" file="Resources/svg/pause.svg"/>
-        <FILE id="pUshPin" name="push_pin.svg" compile="0" resource="1" file="Resources/svg/push_pin.svg"/>
         <FILE id="D2AI1b" name="pencil.svg" compile="0" resource="1" file="Resources/svg/pencil.svg"/>
         <FILE id="zFdUYi" name="planet.svg" compile="0" resource="1" file="Resources/svg/planet.svg"/>
         <FILE id="sfWuFd" name="play.svg" compile="0" resource="1" file="Resources/svg/play.svg"/>

--- a/osci-render.jucer
+++ b/osci-render.jucer
@@ -143,6 +143,7 @@
               file="Resources/svg/oscilloscope.svg"/>
         <FILE id="pStSvg" name="paste.svg" compile="0" resource="1" file="Resources/svg/paste.svg"/>
         <FILE id="f2D5tv" name="pause.svg" compile="0" resource="1" file="Resources/svg/pause.svg"/>
+        <FILE id="pUshPin" name="push_pin.svg" compile="0" resource="1" file="Resources/svg/push_pin.svg"/>
         <FILE id="D2AI1b" name="pencil.svg" compile="0" resource="1" file="Resources/svg/pencil.svg"/>
         <FILE id="zFdUYi" name="planet.svg" compile="0" resource="1" file="Resources/svg/planet.svg"/>
         <FILE id="sfWuFd" name="play.svg" compile="0" resource="1" file="Resources/svg/play.svg"/>

--- a/sosci.jucer
+++ b/sosci.jucer
@@ -77,7 +77,6 @@
         <FILE id="hJHxFY" name="open_in_new.svg" compile="0" resource="1" file="Resources/svg/open_in_new.svg"/>
         <FILE id="pSc1mq" name="osci.svg" compile="0" resource="1" file="Resources/svg/osci.svg"/>
         <FILE id="f2D5tv" name="pause.svg" compile="0" resource="1" file="Resources/svg/pause.svg"/>
-        <FILE id="pUshPin" name="push_pin.svg" compile="0" resource="1" file="Resources/svg/push_pin.svg"/>
         <FILE id="D2AI1b" name="pencil.svg" compile="0" resource="1" file="Resources/svg/pencil.svg"/>
         <FILE id="Tf7MT4" name="play.svg" compile="0" resource="1" file="Resources/svg/play.svg"/>
         <FILE id="PFc2q2" name="random.svg" compile="0" resource="1" file="Resources/svg/random.svg"/>

--- a/sosci.jucer
+++ b/sosci.jucer
@@ -77,6 +77,7 @@
         <FILE id="hJHxFY" name="open_in_new.svg" compile="0" resource="1" file="Resources/svg/open_in_new.svg"/>
         <FILE id="pSc1mq" name="osci.svg" compile="0" resource="1" file="Resources/svg/osci.svg"/>
         <FILE id="f2D5tv" name="pause.svg" compile="0" resource="1" file="Resources/svg/pause.svg"/>
+        <FILE id="pUshPin" name="push_pin.svg" compile="0" resource="1" file="Resources/svg/push_pin.svg"/>
         <FILE id="D2AI1b" name="pencil.svg" compile="0" resource="1" file="Resources/svg/pencil.svg"/>
         <FILE id="Tf7MT4" name="play.svg" compile="0" resource="1" file="Resources/svg/play.svg"/>
         <FILE id="PFc2q2" name="random.svg" compile="0" resource="1" file="Resources/svg/random.svg"/>

--- a/tests/VoiceManagerTest.cpp
+++ b/tests/VoiceManagerTest.cpp
@@ -241,6 +241,16 @@ public:
             expectEquals(vm->getNumPressedNotes(), 0);
         }
 
+        beginTest("allSoundOff clears notes across MIDI channels");
+        {
+            auto [vm, _] = createVM(4);
+            sendNoteOn(*vm, 60, 0.8f, 2);
+            sendNoteOn(*vm, 67, 0.8f, 9);
+            vm->handleMidiEvent(juce::MidiMessage::allSoundOff(1));
+            expectEquals(vm->getNumPressedNotes(), 0);
+            expectEquals(countAudibleVoices(*vm), 0);
+        }
+
         beginTest("velocity-0 noteOn treated as noteOff");
         {
             auto [vm, _] = createVM(4);


### PR DESCRIPTION
## Summary

- redesign Visualiser Settings into responsive, logically grouped sections using the shared osci_gui grid and animated parameter pills
- add trigger source/slope controls, a live line-colour swatch, and fully dynamic settings sizing
- add automatable mute, MIDI input-channel selection and panic commands, plus flattened X/Y routing controls
- improve project shortcuts, recent-project clearing, recording filenames, recent recordings, export reveal behavior, fullscreen state, and complete window-layout reset
- add branded oscilloscope window titles and a persistent Interface option to keep that window on top
- improve Jucewright menu, tooltip, popup, keyboard and screenshot handling
- fix reviewed edge cases around MIDI channel changes, sosci wrapper muting, failed recording exports, grid lifetimes, and extended function keys

## Dependencies

- osci_gui changes: https://github.com/jameshball/osci_gui/pull/5
- Jucewright support was reviewed and landed directly on its `main` branch in commits `ffa139a`, `593d44a`, and `2501749`

## User impact

The settings UI is cleaner, responsive and consistent with the MIDI controls. Common workflow actions are easier to discover, routing and MIDI behavior are automatable, recording workflows report failures correctly, and standalone/window state now matches what the menus display.

## Validation

- Debug standalone builds passed for osci-render and sosci
- Synth and Visualiser test categories passed
- Jucewright CLI/MCP automation fixture passed, including F25 coverage
- Jucewright CI passed on both Ubuntu jobs, macOS, and both Windows jobs
- extensive independent reviews covered realtime safety, state persistence, lifecycle handling, cross-platform input, responsive layout, contrast, accessibility, and simplification

Neither standalone app was launched during the final validation passes.