### PR TITLE
Add Linux transparent popouts and tighten cross-platform window handling

### DIFF
--- a/Source/visualiser/OpenGL_linux.cpp
+++ b/Source/visualiser/OpenGL_linux.cpp
@@ -1,0 +1,186 @@
+#include <JuceHeader.h>
+#include "OpenGL_linux.h"
+
+#if JUCE_LINUX
+#include <EGL/egl.h>
+#include <EGL/eglext.h>
+#include <X11/Xlib.h>
+#include <X11/Xutil.h>
+#include <X11/extensions/Xrender.h>
+
+#include <algorithm>
+#include <atomic>
+#include <map>
+#include <mutex>
+#include <vector>
+
+extern "C" EGLBoolean __real_eglChooseConfig(EGLDisplay display, const EGLint* attributes, EGLConfig* configs, EGLint configSize, EGLint* configCount);
+extern "C" EGLBoolean __real_eglInitialize(EGLDisplay display, EGLint* major, EGLint* minor);
+extern "C" EGLBoolean __real_eglTerminate(EGLDisplay display);
+
+namespace {
+
+struct EGLDisplayReferences {
+    // Initialisation and termination may block inside the driver.
+    std::mutex mutex;
+    std::map<EGLDisplay, unsigned int> counts;
+};
+
+EGLDisplayReferences& getEGLDisplayReferences() {
+    static EGLDisplayReferences references;
+    return references;
+}
+
+std::atomic<VisualID>& getAlphaVisualId() {
+    static std::atomic<VisualID> id{ 0 };
+    return id;
+}
+
+bool requestsAlpha(const EGLint* attributes) {
+    if (attributes == nullptr) {
+        return false;
+    }
+    for (auto* attribute = attributes; attribute[0] != EGL_NONE; attribute += 2) {
+        if (attribute[0] == EGL_ALPHA_SIZE) {
+            return attribute[1] > 0;
+        }
+    }
+    return false;
+}
+
+VisualID getVisualId(EGLDisplay eglDisplay, EGLConfig config) {
+    EGLint visualId = 0;
+    if (eglGetConfigAttrib(eglDisplay, config, EGL_NATIVE_VISUAL_ID, &visualId) != EGL_TRUE) {
+        return 0;
+    }
+    return static_cast<VisualID>(visualId);
+}
+
+bool usesAlphaVisual(EGLDisplay eglDisplay, EGLConfig config) {
+    return getVisualId(eglDisplay, config) == getAlphaVisualId().load(std::memory_order_acquire);
+}
+
+} // namespace
+
+bool osci::hasCompatibleOpenGLVisual(Display* display) {
+    if (display == nullptr) {
+        return false;
+    }
+
+    auto eglDisplay = eglGetPlatformDisplay(EGL_PLATFORM_X11_KHR, display, nullptr);
+    if (eglDisplay == EGL_NO_DISPLAY || eglInitialize(eglDisplay, nullptr, nullptr) != EGL_TRUE) {
+        return false;
+    }
+
+    // Match JUCE's default OpenGLPixelFormat. A compositor-capable ARGB peer is
+    // not sufficient if JUCE's child EGL window would use an opaque X11 visual.
+    const EGLint attributes[] {
+        EGL_SURFACE_TYPE, EGL_WINDOW_BIT,
+        EGL_RENDERABLE_TYPE, EGL_OPENGL_BIT,
+        EGL_RED_SIZE, 8,
+        EGL_GREEN_SIZE, 8,
+        EGL_BLUE_SIZE, 8,
+        EGL_ALPHA_SIZE, 8,
+        EGL_DEPTH_SIZE, 16,
+        EGL_STENCIL_SIZE, 0,
+        EGL_SAMPLE_BUFFERS, 0,
+        EGL_SAMPLES, 0,
+        EGL_NONE,
+    };
+    EGLint configCount = 0;
+    if (__real_eglChooseConfig(eglDisplay, attributes, nullptr, 0, &configCount) != EGL_TRUE || configCount <= 0) {
+        eglTerminate(eglDisplay);
+        return false;
+    }
+
+    std::vector<EGLConfig> configs(static_cast<std::size_t>(configCount));
+    if (__real_eglChooseConfig(eglDisplay, attributes, configs.data(), configCount, &configCount) != EGL_TRUE) {
+        eglTerminate(eglDisplay);
+        return false;
+    }
+    configs.resize(static_cast<std::size_t>(configCount));
+
+    for (const auto config : configs) {
+        const auto visualId = getVisualId(eglDisplay, config);
+        XVisualInfo visualTemplate{};
+        visualTemplate.visualid = visualId;
+        int visualCount = 0;
+        auto* visuals = XGetVisualInfo(display, VisualIDMask, &visualTemplate, &visualCount);
+        bool foundAlphaVisual = false;
+        if (visuals != nullptr && visualCount > 0) {
+            const auto* format = XRenderFindVisualFormat(display, visuals[0].visual);
+            if (format != nullptr && format->type == PictTypeDirect && format->direct.alphaMask != 0) {
+                getAlphaVisualId().store(visualId, std::memory_order_release);
+                foundAlphaVisual = true;
+            }
+        }
+        if (visuals != nullptr) {
+            XFree(visuals);
+        }
+        if (foundAlphaVisual) {
+            break;
+        }
+    }
+    eglTerminate(eglDisplay);
+    return getAlphaVisualId().load(std::memory_order_acquire) != 0;
+}
+
+// JUCE initialises/terminates the same EGL display for each OpenGL context.
+// EGL does not count these calls: hiding one visualiser would otherwise destroy
+// the editor's surfaces too. Terminate only when the last context releases it.
+extern "C" EGLBoolean __wrap_eglInitialize(EGLDisplay display, EGLint* major, EGLint* minor) {
+    auto& references = getEGLDisplayReferences();
+    const std::lock_guard<std::mutex> lock(references.mutex);
+    const auto result = __real_eglInitialize(display, major, minor);
+    if (result == EGL_TRUE) {
+        ++references.counts[display];
+    }
+    return result;
+}
+
+extern "C" EGLBoolean __wrap_eglTerminate(EGLDisplay display) {
+    auto& references = getEGLDisplayReferences();
+    const std::lock_guard<std::mutex> lock(references.mutex);
+    const auto entry = references.counts.find(display);
+    if (entry != references.counts.end()) {
+        if (--entry->second != 0) {
+            return EGL_TRUE;
+        }
+        references.counts.erase(entry);
+    }
+    return __real_eglTerminate(display);
+}
+
+// Mesa exposes both opaque and ARGB native visuals for otherwise identical RGBA
+// configs. JUCE accepts the first match, so prefer an actual depth-32 X11 visual.
+extern "C" EGLBoolean __wrap_eglChooseConfig(EGLDisplay eglDisplay, const EGLint* attributes, EGLConfig* configs, EGLint configSize, EGLint* configCount) {
+    if (configs == nullptr || configSize <= 0 || configCount == nullptr || !requestsAlpha(attributes)
+        || getAlphaVisualId().load(std::memory_order_acquire) == 0) {
+        return __real_eglChooseConfig(eglDisplay, attributes, configs, configSize, configCount);
+    }
+
+    EGLint matchCount = 0;
+    if (__real_eglChooseConfig(eglDisplay, attributes, nullptr, 0, &matchCount) != EGL_TRUE || matchCount <= 0) {
+        return __real_eglChooseConfig(eglDisplay, attributes, configs, configSize, configCount);
+    }
+
+    std::vector<EGLConfig> matches(static_cast<std::size_t>(matchCount));
+    if (__real_eglChooseConfig(eglDisplay, attributes, matches.data(), matchCount, &matchCount) != EGL_TRUE) {
+        return EGL_FALSE;
+    }
+    matches.resize(static_cast<std::size_t>(matchCount));
+
+    auto alphaConfig = std::find_if(matches.begin(), matches.end(), [eglDisplay](EGLConfig config) {
+        return usesAlphaVisual(eglDisplay, config);
+    });
+    if (alphaConfig != matches.end()) {
+        std::rotate(matches.begin(), alphaConfig, std::next(alphaConfig));
+    }
+
+    const auto copyCount = juce::jmin(configSize, matchCount);
+    std::copy_n(matches.begin(), copyCount, configs);
+    *configCount = copyCount;
+    return EGL_TRUE;
+}
+
+#endif

--- a/Source/visualiser/OpenGL_linux.h
+++ b/Source/visualiser/OpenGL_linux.h
@@ -1,0 +1,7 @@
+#pragma once
+
+struct _XDisplay;
+
+namespace osci {
+bool hasCompatibleOpenGLVisual(_XDisplay* display);
+}

--- a/Source/visualiser/TransparentWindow.cpp
+++ b/Source/visualiser/TransparentWindow.cpp
@@ -74,18 +74,7 @@ void TransparentWindowToolbar::setState(const TransparentWindowToolbarState& new
 }
 
 bool TransparentWindowToolbar::hitTest(int x, int y) {
-    if (!state.frameVisible) {
-        return false;
-    }
-    if (y < toolbarHeight) {
-        return true;
-    }
-    for (auto* child : getChildren()) {
-        if (child->getBounds().contains(x, y)) {
-            return true;
-        }
-    }
-    return false;
+    return state.frameVisible && getLocalBounds().removeFromTop(toolbarHeight).contains(x, y);
 }
 
 void TransparentWindowToolbar::paint(juce::Graphics& g) {
@@ -164,8 +153,6 @@ void TransparentWindowToolbar::mouseDrag(const juce::MouseEvent& event) {
     }
 }
 
-void TransparentWindowToolbar::mouseUp(const juce::MouseEvent&) {}
-
 TransparentWindow::TransparentWindow(juce::String name, TransparentWindowState initialState)
     : juce::DocumentWindow(name,
                            isTransparencySupported() ? juce::Colours::transparentBlack : juce::Colours::black,
@@ -174,9 +161,9 @@ TransparentWindow::TransparentWindow(juce::String name, TransparentWindowState i
       pinned(initialState.alwaysOnTop),
       frameRequestedVisible(initialState.frameVisible),
       allMouseEventsPassThrough(initialState.mouseEventsPassThrough) {
-    applyAlwaysOnTop();
     setUsingNativeTitleBar(!isTransparencySupported());
     setResizable(true, false);
+    applyAlwaysOnTop();
     if (!initialState.normalBounds.isEmpty()) {
         setBounds(initialState.normalBounds);
     }
@@ -206,7 +193,9 @@ TransparentWindow::~TransparentWindow() {
     if (dragSurface != nullptr) {
         dragSurface->removeMouseListener(this);
     }
-    setNativeIgnoresMouseEvents(false);
+    if (isTransparencySupported()) {
+        setNativeIgnoresMouseEvents(false);
+    }
 }
 
 void TransparentWindow::setContent(std::unique_ptr<juce::Component> content) {
@@ -240,12 +229,10 @@ void TransparentWindow::setTransparencyEnabled(bool enabled) {
         if (transparencyEnabled && !transparentFullScreen) {
             fullScreenTransitionPending = true;
             reenterFullScreenAfterTransition = true;
-#if JUCE_LINUX
             transparentFullScreenTransitionTime = juce::Time::getMillisecondCounter() + 250;
             juce::ResizableWindow::setFullScreen(false);
+#if JUCE_LINUX
             configureNativeTransparency();
-#else
-            juce::ResizableWindow::setFullScreen(false);
 #endif
         } else if (!transparencyEnabled) {
             reenterFullScreenAfterTransition = false;
@@ -256,9 +243,7 @@ void TransparentWindow::setTransparencyEnabled(bool enabled) {
                     const juce::ScopedValueSetter<bool> settingBounds(settingTransparentFullScreenBounds, true);
                     setBounds(boundsBeforeFullScreen);
                 }
-#if JUCE_MAC
                 setMovesToActiveSpace(false);
-#endif
             }
             fullScreenTransitionPending = true;
             juce::ResizableWindow::setFullScreen(true);
@@ -344,9 +329,7 @@ void TransparentWindow::toggleFullScreen() {
         if (transparentFullScreen) {
             enterTransparentFullScreen();
         } else {
-#if JUCE_MAC
             setMovesToActiveSpace(false);
-#endif
             juce::ResizableWindow::setFullScreen(true);
 #if JUCE_WINDOWS
             scheduleNativeFullScreenBoundsSync();
@@ -359,9 +342,7 @@ void TransparentWindow::toggleFullScreen() {
                 setBounds(boundsBeforeFullScreen);
             }
             transparentFullScreen = false;
-#if JUCE_MAC
             setMovesToActiveSpace(false);
-#endif
         } else {
             juce::ResizableWindow::setFullScreen(false);
         }
@@ -380,6 +361,9 @@ void TransparentWindow::restoreSavedFullScreen() {
 }
 
 void TransparentWindow::refreshPresentationSurface() {
+    if (!isTransparencySupported()) {
+        return;
+    }
 #if JUCE_LINUX
     configureNativeTransparency();
 #endif
@@ -426,7 +410,11 @@ void TransparentWindow::closeButtonPressed() {
 
 void TransparentWindow::visibilityChanged() {
     juce::DocumentWindow::visibilityChanged();
+    if (isVisible()) {
+        applyAlwaysOnTop();
+    }
     if (isVisible() && isTransparencySupported()) {
+        windowCornersConfigured = false;
         configureNativeTransparency();
         updatePresentation();
     }
@@ -434,12 +422,13 @@ void TransparentWindow::visibilityChanged() {
 
 void TransparentWindow::resized() {
     juce::DocumentWindow::resized();
-#if JUCE_LINUX
+    if (!isTransparencySupported()) {
+        return;
+    }
     if (reenterFullScreenAfterTransition) {
         transparentFullScreenTransitionTime = juce::Time::getMillisecondCounter() + 250;
     }
-#endif
-    if (isTransparencySupported() && getContentComponent() != nullptr) {
+    if (getContentComponent() != nullptr) {
         getContentComponent()->setBounds(getLocalBounds());
     }
     if (toolbar != nullptr) {
@@ -453,7 +442,6 @@ void TransparentWindow::resized() {
 #endif
     if (fullScreenRequested && transparentFullScreen && !settingTransparentFullScreenBounds
         && !transparentFullScreenBounds.isEmpty() && getBounds() != transparentFullScreenBounds) {
-#if JUCE_LINUX
         if (static_cast<std::int32_t>(juce::Time::getMillisecondCounter() - transparentFullScreenTransitionTime) < 0) {
             transparentFullScreen = false;
             reenterFullScreenAfterTransition = true;
@@ -461,7 +449,6 @@ void TransparentWindow::resized() {
             updatePresentation();
             return;
         }
-#endif
         leaveTransparentFullScreenAfterResize();
     }
     const bool nativeFullScreen = juce::ResizableWindow::isFullScreen();
@@ -502,9 +489,7 @@ void TransparentWindow::leaveTransparentFullScreenAfterResize() {
     transparentFullScreen = false;
     transparentFullScreenBounds = {};
     reenterFullScreenAfterTransition = false;
-#if JUCE_MAC
     setMovesToActiveSpace(false);
-#endif
     applyAlwaysOnTop();
     stateChanged(getWindowState());
     updatePresentation();
@@ -512,9 +497,7 @@ void TransparentWindow::leaveTransparentFullScreenAfterResize() {
 
 void TransparentWindow::enterTransparentFullScreen() {
     transparentFullScreen = true;
-#if JUCE_MAC
     setMovesToActiveSpace(true);
-#endif
     const auto displayBounds = boundsBeforeFullScreen.isEmpty() ? getBounds() : boundsBeforeFullScreen;
     auto* display = juce::Desktop::getInstance().getDisplays().getDisplayForRect(displayBounds);
     if (display != nullptr) {
@@ -526,9 +509,7 @@ void TransparentWindow::enterTransparentFullScreen() {
         transparentFullScreenBounds = getTransparentFullScreenBounds(display->logicalBounds.toNearestInt());
 #endif
         const juce::ScopedValueSetter<bool> settingBounds(settingTransparentFullScreenBounds, true);
-#if JUCE_LINUX
         transparentFullScreenTransitionTime = juce::Time::getMillisecondCounter() + 250;
-#endif
         setBounds(transparentFullScreenBounds);
 #if JUCE_LINUX
         // Stale ConfigureNotify events can leave JUCE's component bounds ahead
@@ -563,6 +544,11 @@ void TransparentWindow::timerCallback() {
 }
 
 void TransparentWindow::updatePresentation() {
+    if (!isTransparencySupported()) {
+        fullScreenTransitionPending = false;
+        stopTimer();
+        return;
+    }
     const auto now = juce::Time::getMillisecondCounter();
     if (presentationPaused) {
         clickThroughHintVisible = false;
@@ -578,14 +564,15 @@ void TransparentWindow::updatePresentation() {
     }
 
     const bool nativeFullScreen = juce::ResizableWindow::isFullScreen();
+    // Native fullscreen flags can clear before the window manager finishes resizing.
+    bool canReenterTransparentFullScreen = reenterFullScreenAfterTransition && !nativeFullScreen
+                                       && static_cast<std::int32_t>(now - transparentFullScreenTransitionTime) >= 0;
 #if JUCE_LINUX
-    const bool canReenterTransparentFullScreen = !nativeFullScreen
-                                               && !isNativeFullScreenStateActive()
-                                               && static_cast<std::int32_t>(now - transparentFullScreenTransitionTime) >= 0;
-#else
-    const bool canReenterTransparentFullScreen = !nativeFullScreen;
+    if (canReenterTransparentFullScreen) {
+        canReenterTransparentFullScreen = !isNativeFullScreenStateActive();
+    }
 #endif
-    if (reenterFullScreenAfterTransition && canReenterTransparentFullScreen) {
+    if (canReenterTransparentFullScreen) {
         reenterFullScreenAfterTransition = false;
         enterTransparentFullScreen();
     }
@@ -609,12 +596,8 @@ void TransparentWindow::updatePresentation() {
         }
     }
 
-    if (presentationRefreshActive && getAlphaMaskGeneration() != presentationRefreshGeneration) {
-        presentationRefreshActive = false;
-        configureNativeTransparency();
-        applyAlwaysOnTop();
-    }
-    if (presentationRefreshActive && static_cast<std::int32_t>(now - presentationRefreshDeadline) >= 0) {
+    if (presentationRefreshActive && (getAlphaMaskGeneration() != presentationRefreshGeneration
+                                     || static_cast<std::int32_t>(now - presentationRefreshDeadline) >= 0)) {
         presentationRefreshActive = false;
         configureNativeTransparency();
         applyAlwaysOnTop();
@@ -720,12 +703,11 @@ void TransparentWindow::applyNativeInteraction(bool ignoresMouseEvents) {
     setNativeIgnoresMouseEvents(ignoresMouseEvents);
 }
 
-void TransparentWindow::applyAlwaysOnTop() {
 #if !JUCE_LINUX
+void TransparentWindow::applyAlwaysOnTop() {
     setAlwaysOnTop(pinned);
-#endif
-    setNativeAlwaysOnTop(pinned);
 }
+#endif
 
 void TransparentWindow::updateResizeBorderVisibility(bool visible) {
     if (resizeBorderVisibilityInitialised && resizeBorderVisible == visible) {

--- a/Source/visualiser/TransparentWindow.cpp
+++ b/Source/visualiser/TransparentWindow.cpp
@@ -190,6 +190,9 @@ TransparentWindow::TransparentWindow(juce::String name, TransparentWindowState i
 
 TransparentWindow::~TransparentWindow() {
     stopTimer();
+#if JUCE_MAC
+    removeFullScreenExitObserver();
+#endif
     if (dragSurface != nullptr) {
         dragSurface->removeMouseListener(this);
     }
@@ -229,7 +232,11 @@ void TransparentWindow::setTransparencyEnabled(bool enabled) {
         if (transparencyEnabled && !transparentFullScreen) {
             fullScreenTransitionPending = true;
             reenterFullScreenAfterTransition = true;
+#if JUCE_LINUX
             transparentFullScreenTransitionTime = juce::Time::getMillisecondCounter() + 250;
+#elif JUCE_MAC
+            observeNativeFullScreenExit();
+#endif
             juce::ResizableWindow::setFullScreen(false);
 #if JUCE_LINUX
             configureNativeTransparency();
@@ -425,9 +432,11 @@ void TransparentWindow::resized() {
     if (!isTransparencySupported()) {
         return;
     }
+#if JUCE_LINUX
     if (reenterFullScreenAfterTransition) {
         transparentFullScreenTransitionTime = juce::Time::getMillisecondCounter() + 250;
     }
+#endif
     if (getContentComponent() != nullptr) {
         getContentComponent()->setBounds(getLocalBounds());
     }
@@ -442,6 +451,7 @@ void TransparentWindow::resized() {
 #endif
     if (fullScreenRequested && transparentFullScreen && !settingTransparentFullScreenBounds
         && !transparentFullScreenBounds.isEmpty() && getBounds() != transparentFullScreenBounds) {
+#if JUCE_LINUX
         if (static_cast<std::int32_t>(juce::Time::getMillisecondCounter() - transparentFullScreenTransitionTime) < 0) {
             transparentFullScreen = false;
             reenterFullScreenAfterTransition = true;
@@ -449,6 +459,7 @@ void TransparentWindow::resized() {
             updatePresentation();
             return;
         }
+#endif
         leaveTransparentFullScreenAfterResize();
     }
     const bool nativeFullScreen = juce::ResizableWindow::isFullScreen();
@@ -509,7 +520,9 @@ void TransparentWindow::enterTransparentFullScreen() {
         transparentFullScreenBounds = getTransparentFullScreenBounds(display->logicalBounds.toNearestInt());
 #endif
         const juce::ScopedValueSetter<bool> settingBounds(settingTransparentFullScreenBounds, true);
+#if JUCE_LINUX
         transparentFullScreenTransitionTime = juce::Time::getMillisecondCounter() + 250;
+#endif
         setBounds(transparentFullScreenBounds);
 #if JUCE_LINUX
         // Stale ConfigureNotify events can leave JUCE's component bounds ahead
@@ -564,13 +577,15 @@ void TransparentWindow::updatePresentation() {
     }
 
     const bool nativeFullScreen = juce::ResizableWindow::isFullScreen();
-    // Native fullscreen flags can clear before the window manager finishes resizing.
-    bool canReenterTransparentFullScreen = reenterFullScreenAfterTransition && !nativeFullScreen
-                                       && static_cast<std::int32_t>(now - transparentFullScreenTransitionTime) >= 0;
+    bool canReenterTransparentFullScreen = reenterFullScreenAfterTransition && !nativeFullScreen;
 #if JUCE_LINUX
+    // X11 has no fullscreen-exit completion notification. Allow queued WM resizes to settle.
     if (canReenterTransparentFullScreen) {
-        canReenterTransparentFullScreen = !isNativeFullScreenStateActive();
+        canReenterTransparentFullScreen = static_cast<std::int32_t>(now - transparentFullScreenTransitionTime) >= 0
+                                      && !isNativeFullScreenStateActive();
     }
+#elif JUCE_MAC
+    canReenterTransparentFullScreen = canReenterTransparentFullScreen && fullScreenExitObserver == nullptr;
 #endif
     if (canReenterTransparentFullScreen) {
         reenterFullScreenAfterTransition = false;

--- a/Source/visualiser/TransparentWindow.cpp
+++ b/Source/visualiser/TransparentWindow.cpp
@@ -380,6 +380,9 @@ void TransparentWindow::restoreSavedFullScreen() {
 }
 
 void TransparentWindow::refreshPresentationSurface() {
+#if JUCE_LINUX
+    configureNativeTransparency();
+#endif
     presentationRefreshGeneration = getAlphaMaskGeneration();
     presentationRefreshDeadline = juce::Time::getMillisecondCounter() + 1000;
     presentationRefreshActive = true;
@@ -443,6 +446,11 @@ void TransparentWindow::resized() {
         toolbar->setBounds(getLocalBounds());
         toolbar->toFront(false);
     }
+#if JUCE_LINUX
+    if (windowCornersRounded) {
+        setNativeRoundedWindowRegion(cornerRadius);
+    }
+#endif
     if (fullScreenRequested && transparentFullScreen && !settingTransparentFullScreenBounds
         && !transparentFullScreenBounds.isEmpty() && getBounds() != transparentFullScreenBounds) {
 #if JUCE_LINUX
@@ -450,6 +458,7 @@ void TransparentWindow::resized() {
             transparentFullScreen = false;
             reenterFullScreenAfterTransition = true;
             transparentFullScreenTransitionTime = juce::Time::getMillisecondCounter() + 250;
+            updatePresentation();
             return;
         }
 #endif

--- a/Source/visualiser/TransparentWindow.cpp
+++ b/Source/visualiser/TransparentWindow.cpp
@@ -90,13 +90,18 @@ bool TransparentWindowToolbar::hitTest(int x, int y) {
 
 void TransparentWindowToolbar::paint(juce::Graphics& g) {
     if (state.frameVisible) {
-        constexpr float cornerRadius = 11.0f;
         auto bounds = getLocalBounds();
+        const juce::Graphics::ScopedSaveState saveState(g);
+        if (!state.fullScreen) {
+            juce::Path windowShape;
+            windowShape.addRoundedRectangle(bounds.toFloat(), TransparentWindow::cornerRadius);
+            g.reduceClipRegion(windowShape);
+        }
         g.setColour(osci::Colours::veryDark());
         g.fillRect(bounds.removeFromTop(toolbarHeight));
         if (!state.fullScreen) {
             g.setColour(juce::Colours::white.withAlpha(0.5f));
-            g.drawRoundedRectangle(getLocalBounds().toFloat().reduced(0.5f), cornerRadius - 0.5f, 1.0f);
+            g.drawRoundedRectangle(getLocalBounds().toFloat().reduced(0.5f), TransparentWindow::cornerRadius - 0.5f, 1.0f);
         }
     }
     if (state.clickThroughHintVisible) {
@@ -169,7 +174,7 @@ TransparentWindow::TransparentWindow(juce::String name, TransparentWindowState i
       pinned(initialState.alwaysOnTop),
       frameRequestedVisible(initialState.frameVisible),
       allMouseEventsPassThrough(initialState.mouseEventsPassThrough) {
-    setAlwaysOnTop(pinned);
+    applyAlwaysOnTop();
     setUsingNativeTitleBar(!isTransparencySupported());
     setResizable(true, false);
     if (!initialState.normalBounds.isEmpty()) {
@@ -232,11 +237,16 @@ void TransparentWindow::setTransparencyEnabled(bool enabled) {
     }
     transparencyEnabled = enabled;
     if (fullScreenRequested) {
-#if JUCE_WINDOWS || JUCE_MAC
         if (transparencyEnabled && !transparentFullScreen) {
-            reenterFullScreenAfterTransition = true;
             fullScreenTransitionPending = true;
+            reenterFullScreenAfterTransition = true;
+#if JUCE_LINUX
+            transparentFullScreenTransitionTime = juce::Time::getMillisecondCounter() + 250;
             juce::ResizableWindow::setFullScreen(false);
+            configureNativeTransparency();
+#else
+            juce::ResizableWindow::setFullScreen(false);
+#endif
         } else if (!transparencyEnabled) {
             reenterFullScreenAfterTransition = false;
             if (transparentFullScreen) {
@@ -256,15 +266,12 @@ void TransparentWindow::setTransparencyEnabled(bool enabled) {
             scheduleNativeFullScreenBoundsSync();
 #endif
         }
-#endif
         updatePresentation();
         return;
     }
-#if JUCE_WINDOWS || JUCE_MAC
     if (reenterFullScreenAfterTransition) {
         return;
     }
-#endif
     if (transparencyEnabled) {
         refreshPresentationSurface();
     } else {
@@ -313,7 +320,7 @@ void TransparentWindow::setPinned(bool shouldBePinned) {
         return;
     }
     pinned = shouldBePinned;
-    setAlwaysOnTop(pinned);
+    applyAlwaysOnTop();
 #if JUCE_WINDOWS
     if (isTransparencySupported()) {
         refreshPresentationSurface();
@@ -329,9 +336,8 @@ void TransparentWindow::setPinned(bool shouldBePinned) {
 void TransparentWindow::toggleFullScreen() {
     fullScreenRequested = !fullScreenRequested;
     fullScreenTransitionPending = true;
-#if JUCE_WINDOWS || JUCE_MAC
     reenterFullScreenAfterTransition = false;
-    setAlwaysOnTop(pinned);
+    applyAlwaysOnTop();
     if (fullScreenRequested) {
         boundsBeforeFullScreen = getBounds();
         transparentFullScreen = transparencyEnabled;
@@ -361,9 +367,6 @@ void TransparentWindow::toggleFullScreen() {
         }
         transparentFullScreenBounds = {};
     }
-#else
-    juce::ResizableWindow::setFullScreen(fullScreenRequested);
-#endif
     stateChanged(getWindowState());
     updatePresentation();
 }
@@ -386,11 +389,9 @@ void TransparentWindow::refreshPresentationSurface() {
 
 TransparentWindowState TransparentWindow::getWindowState() const {
     auto normalBounds = getBounds();
-#if JUCE_WINDOWS || JUCE_MAC
     if (fullScreenRequested && !boundsBeforeFullScreen.isEmpty()) {
         normalBounds = boundsBeforeFullScreen;
     }
-#endif
     return {
         .normalBounds = normalBounds,
         .fullScreen = fullScreenRequested,
@@ -430,6 +431,11 @@ void TransparentWindow::visibilityChanged() {
 
 void TransparentWindow::resized() {
     juce::DocumentWindow::resized();
+#if JUCE_LINUX
+    if (reenterFullScreenAfterTransition) {
+        transparentFullScreenTransitionTime = juce::Time::getMillisecondCounter() + 250;
+    }
+#endif
     if (isTransparencySupported() && getContentComponent() != nullptr) {
         getContentComponent()->setBounds(getLocalBounds());
     }
@@ -437,12 +443,18 @@ void TransparentWindow::resized() {
         toolbar->setBounds(getLocalBounds());
         toolbar->toFront(false);
     }
-#if JUCE_MAC || JUCE_WINDOWS
     if (fullScreenRequested && transparentFullScreen && !settingTransparentFullScreenBounds
         && !transparentFullScreenBounds.isEmpty() && getBounds() != transparentFullScreenBounds) {
+#if JUCE_LINUX
+        if (static_cast<std::int32_t>(juce::Time::getMillisecondCounter() - transparentFullScreenTransitionTime) < 0) {
+            transparentFullScreen = false;
+            reenterFullScreenAfterTransition = true;
+            transparentFullScreenTransitionTime = juce::Time::getMillisecondCounter() + 250;
+            return;
+        }
+#endif
         leaveTransparentFullScreenAfterResize();
     }
-#endif
     const bool nativeFullScreen = juce::ResizableWindow::isFullScreen();
     const bool frameVisible = hasAppliedInteractionPolicy ? appliedInteractionPolicy.frameVisible : frameRequestedVisible;
     updateResizeBorderVisibility(frameVisible && !fullScreenRequested && !nativeFullScreen);
@@ -478,21 +490,18 @@ void TransparentWindow::mouseDrag(const juce::MouseEvent& event) {
 void TransparentWindow::leaveTransparentFullScreenAfterResize() {
     fullScreenRequested = false;
     fullScreenTransitionPending = false;
-#if JUCE_WINDOWS || JUCE_MAC
     transparentFullScreen = false;
     transparentFullScreenBounds = {};
     reenterFullScreenAfterTransition = false;
-#endif
 #if JUCE_MAC
     setMovesToActiveSpace(false);
 #endif
-    setAlwaysOnTop(pinned);
+    applyAlwaysOnTop();
     stateChanged(getWindowState());
     updatePresentation();
 }
 
 void TransparentWindow::enterTransparentFullScreen() {
-#if JUCE_WINDOWS || JUCE_MAC
     transparentFullScreen = true;
 #if JUCE_MAC
     setMovesToActiveSpace(true);
@@ -500,12 +509,25 @@ void TransparentWindow::enterTransparentFullScreen() {
     const auto displayBounds = boundsBeforeFullScreen.isEmpty() ? getBounds() : boundsBeforeFullScreen;
     auto* display = juce::Desktop::getInstance().getDisplays().getDisplayForRect(displayBounds);
     if (display != nullptr) {
+#if JUCE_LINUX
+        // A normal X11 window is constrained to the desktop work area. Matching
+        // it avoids mistaking the window manager's adjustment for a user resize.
+        transparentFullScreenBounds = getTransparentFullScreenBounds(display->userBounds.toNearestInt());
+#else
         transparentFullScreenBounds = getTransparentFullScreenBounds(display->logicalBounds.toNearestInt());
+#endif
         const juce::ScopedValueSetter<bool> settingBounds(settingTransparentFullScreenBounds, true);
+#if JUCE_LINUX
+        transparentFullScreenTransitionTime = juce::Time::getMillisecondCounter() + 250;
+#endif
         setBounds(transparentFullScreenBounds);
+#if JUCE_LINUX
+        // Stale ConfigureNotify events can leave JUCE's component bounds ahead
+        // of the native X11 peer after leaving native fullscreen.
+        setNativeBounds(transparentFullScreenBounds);
+#endif
     }
     fullScreenTransitionPending = true;
-#endif
 }
 
 #if JUCE_WINDOWS
@@ -547,8 +569,14 @@ void TransparentWindow::updatePresentation() {
     }
 
     const bool nativeFullScreen = juce::ResizableWindow::isFullScreen();
-#if JUCE_WINDOWS || JUCE_MAC
-    if (reenterFullScreenAfterTransition && !nativeFullScreen) {
+#if JUCE_LINUX
+    const bool canReenterTransparentFullScreen = !nativeFullScreen
+                                               && !isNativeFullScreenStateActive()
+                                               && static_cast<std::int32_t>(now - transparentFullScreenTransitionTime) >= 0;
+#else
+    const bool canReenterTransparentFullScreen = !nativeFullScreen;
+#endif
+    if (reenterFullScreenAfterTransition && canReenterTransparentFullScreen) {
         reenterFullScreenAfterTransition = false;
         enterTransparentFullScreen();
     }
@@ -557,7 +585,7 @@ void TransparentWindow::updatePresentation() {
     if (fullScreenTransitionPending && fullScreenTransitionComplete) {
         fullScreenTransitionPending = false;
         configureNativeTransparency();
-        setAlwaysOnTop(pinned);
+        applyAlwaysOnTop();
         refreshOpenGLSurfaceTransparency();
 #if JUCE_WINDOWS
         if (getAlphaHitTestComponent() != nullptr) {
@@ -571,17 +599,16 @@ void TransparentWindow::updatePresentation() {
             transparentFullScreen = false;
         }
     }
-#endif
 
     if (presentationRefreshActive && getAlphaMaskGeneration() != presentationRefreshGeneration) {
         presentationRefreshActive = false;
         configureNativeTransparency();
-        setAlwaysOnTop(pinned);
+        applyAlwaysOnTop();
     }
     if (presentationRefreshActive && static_cast<std::int32_t>(now - presentationRefreshDeadline) >= 0) {
         presentationRefreshActive = false;
         configureNativeTransparency();
-        setAlwaysOnTop(pinned);
+        applyAlwaysOnTop();
     }
 
     const bool fullPassThroughActive = transparencyEnabled && allMouseEventsPassThrough && !presentationPaused;
@@ -603,7 +630,7 @@ void TransparentWindow::updatePresentation() {
     const bool framedWindow = interactionPolicy.frameVisible && !fullScreenActive;
     updateResizeBorderVisibility(framedWindow);
     if (!windowCornersConfigured || windowCornersRounded != framedWindow) {
-        setNativeRoundedWindowRegion(framedWindow ? 11.0f : 0.0f);
+        setNativeRoundedWindowRegion(framedWindow ? cornerRadius : 0.0f);
         windowCornersConfigured = true;
         windowCornersRounded = framedWindow;
     }
@@ -659,9 +686,7 @@ void TransparentWindow::updatePresentation() {
 
     const bool needsTimer = interactionPolicy.mode == TransparentWindowInteractionMode::alphaAware
                          || fullScreenTransitionPending
-#if JUCE_WINDOWS || JUCE_MAC
                          || reenterFullScreenAfterTransition
-#endif
                          || (transparencyEnabled && presentationRefreshActive)
                          || (transparencyEnabled && clickThroughHintVisible);
     if (needsTimer && !isTimerRunning()) {
@@ -684,6 +709,13 @@ void TransparentWindow::applyNativeInteraction(bool ignoresMouseEvents) {
     }
     nativeIgnoresMouseEvents = ignoresMouseEvents;
     setNativeIgnoresMouseEvents(ignoresMouseEvents);
+}
+
+void TransparentWindow::applyAlwaysOnTop() {
+#if !JUCE_LINUX
+    setAlwaysOnTop(pinned);
+#endif
+    setNativeAlwaysOnTop(pinned);
 }
 
 void TransparentWindow::updateResizeBorderVisibility(bool visible) {

--- a/Source/visualiser/TransparentWindow.h
+++ b/Source/visualiser/TransparentWindow.h
@@ -80,6 +80,10 @@ public:
     void restoreSavedFullScreen();
     void refreshPresentationSurface();
     void saveWindowState();
+#if JUCE_MAC
+    bool deferCloseUntilFullScreenExit();
+    void cancelDeferredClose() { closeAfterFullScreenExit = false; }
+#endif
 
     bool isFullScreenRequested() const { return fullScreenRequested; }
     bool isFrameVisibleRequested() const { return frameRequestedVisible; }
@@ -151,6 +155,7 @@ private:
     std::uint32_t transparentFullScreenTransitionTime = 0;
 #elif JUCE_MAC
     void* fullScreenExitObserver = nullptr;
+    bool closeAfterFullScreenExit = false;
 #endif
     bool pinned = true;
     bool frameRequestedVisible = true;

--- a/Source/visualiser/TransparentWindow.h
+++ b/Source/visualiser/TransparentWindow.h
@@ -129,6 +129,9 @@ private:
 #if JUCE_LINUX
     bool isNativeFullScreenStateActive() const;
     void setNativeBounds(juce::Rectangle<int> bounds);
+#elif JUCE_MAC
+    void observeNativeFullScreenExit();
+    void removeFullScreenExitObserver();
 #endif
 
     std::unique_ptr<TransparentWindowToolbar> toolbar;
@@ -144,7 +147,11 @@ private:
     bool transparentFullScreen = false;
     bool settingTransparentFullScreenBounds = false;
     bool reenterFullScreenAfterTransition = false;
+#if JUCE_LINUX
     std::uint32_t transparentFullScreenTransitionTime = 0;
+#elif JUCE_MAC
+    void* fullScreenExitObserver = nullptr;
+#endif
     bool pinned = true;
     bool frameRequestedVisible = true;
     AlphaInteractionHold alphaInteractionHold;

--- a/Source/visualiser/TransparentWindow.h
+++ b/Source/visualiser/TransparentWindow.h
@@ -44,7 +44,6 @@ public:
     void mouseDown(const juce::MouseEvent& event) override;
     void mouseDoubleClick(const juce::MouseEvent& event) override;
     void mouseDrag(const juce::MouseEvent& event) override;
-    void mouseUp(const juce::MouseEvent& event) override;
 
 private:
     static constexpr int toolbarHeight = 24;
@@ -125,7 +124,6 @@ private:
     void applyAlwaysOnTop();
     void setNativeIgnoresMouseEvents(bool ignoresMouseEvents);
     bool isNativeMouseInteractionStateApplied(bool ignoresMouseEvents) const;
-    void setNativeAlwaysOnTop(bool alwaysOnTop);
     void setMovesToActiveSpace(bool shouldMove);
     void setNativeRoundedWindowRegion(float cornerRadius);
 #if JUCE_LINUX
@@ -146,9 +144,7 @@ private:
     bool transparentFullScreen = false;
     bool settingTransparentFullScreenBounds = false;
     bool reenterFullScreenAfterTransition = false;
-#if JUCE_LINUX
     std::uint32_t transparentFullScreenTransitionTime = 0;
-#endif
     bool pinned = true;
     bool frameRequestedVisible = true;
     AlphaInteractionHold alphaInteractionHold;

--- a/Source/visualiser/TransparentWindow.h
+++ b/Source/visualiser/TransparentWindow.h
@@ -63,6 +63,8 @@ private:
 class TransparentWindow : public juce::DocumentWindow,
                           private juce::Timer {
 public:
+    static constexpr float cornerRadius = 11.0f;
+
     TransparentWindow(juce::String name, TransparentWindowState initialState);
     ~TransparentWindow() override;
 
@@ -120,10 +122,16 @@ private:
     static bool supportsClickThroughInTransparentFullScreen();
     static juce::Rectangle<int> getTransparentFullScreenBounds(juce::Rectangle<int> displayBounds);
     void configureNativeTransparency();
+    void applyAlwaysOnTop();
     void setNativeIgnoresMouseEvents(bool ignoresMouseEvents);
     bool isNativeMouseInteractionStateApplied(bool ignoresMouseEvents) const;
+    void setNativeAlwaysOnTop(bool alwaysOnTop);
     void setMovesToActiveSpace(bool shouldMove);
     void setNativeRoundedWindowRegion(float cornerRadius);
+#if JUCE_LINUX
+    bool isNativeFullScreenStateActive() const;
+    void setNativeBounds(juce::Rectangle<int> bounds);
+#endif
 
     std::unique_ptr<TransparentWindowToolbar> toolbar;
     juce::Component* dragSurface = nullptr;
@@ -133,12 +141,13 @@ private:
     bool restoreFullScreen = false;
     bool fullScreenRequested = false;
     bool fullScreenTransitionPending = false;
-#if JUCE_WINDOWS || JUCE_MAC
     juce::Rectangle<int> boundsBeforeFullScreen;
     juce::Rectangle<int> transparentFullScreenBounds;
     bool transparentFullScreen = false;
     bool settingTransparentFullScreenBounds = false;
     bool reenterFullScreenAfterTransition = false;
+#if JUCE_LINUX
+    std::uint32_t transparentFullScreenTransitionTime = 0;
 #endif
     bool pinned = true;
     bool frameRequestedVisible = true;

--- a/Source/visualiser/TransparentWindowInteraction.h
+++ b/Source/visualiser/TransparentWindowInteraction.h
@@ -31,7 +31,8 @@ struct TransparentWindowInteractionPolicy {
 
 inline TransparentWindowInteractionPolicy deriveTransparentWindowInteractionPolicy(
     const TransparentWindowInteractionContext& context) {
-    const bool passAll = context.transparencyEnabled && context.passThroughRequested && !context.paused;
+    const bool passAll = context.transparencyEnabled && context.passThroughRequested
+                      && !context.paused && context.alphaClickThroughAllowed;
 
     TransparentWindowInteractionPolicy policy;
     policy.frameVisible = (context.frameRequestedVisible || context.paused) && !passAll;

--- a/Source/visualiser/TransparentWindow_fallback.cpp
+++ b/Source/visualiser/TransparentWindow_fallback.cpp
@@ -11,7 +11,6 @@ juce::Rectangle<int> TransparentWindow::getTransparentFullScreenBounds(juce::Rec
 void TransparentWindow::configureNativeTransparency() {}
 void TransparentWindow::setNativeIgnoresMouseEvents(bool) {}
 bool TransparentWindow::isNativeMouseInteractionStateApplied(bool) const { return true; }
-void TransparentWindow::setNativeAlwaysOnTop(bool) {}
 
 void TransparentWindow::setMovesToActiveSpace(bool) {}
 void TransparentWindow::setNativeRoundedWindowRegion(float) {}

--- a/Source/visualiser/TransparentWindow_fallback.cpp
+++ b/Source/visualiser/TransparentWindow_fallback.cpp
@@ -1,6 +1,6 @@
 #include "TransparentWindow.h"
 
-#if !JUCE_MAC && !JUCE_WINDOWS
+#if !JUCE_MAC && !JUCE_WINDOWS && !JUCE_LINUX
 bool TransparentWindow::isTransparencySupported() {
     return false;
 }
@@ -11,6 +11,7 @@ juce::Rectangle<int> TransparentWindow::getTransparentFullScreenBounds(juce::Rec
 void TransparentWindow::configureNativeTransparency() {}
 void TransparentWindow::setNativeIgnoresMouseEvents(bool) {}
 bool TransparentWindow::isNativeMouseInteractionStateApplied(bool) const { return true; }
+void TransparentWindow::setNativeAlwaysOnTop(bool) {}
 
 void TransparentWindow::setMovesToActiveSpace(bool) {}
 void TransparentWindow::setNativeRoundedWindowRegion(float) {}

--- a/Source/visualiser/TransparentWindow_linux.cpp
+++ b/Source/visualiser/TransparentWindow_linux.cpp
@@ -1,0 +1,383 @@
+#include "TransparentWindow.h"
+
+#if JUCE_LINUX
+#include <EGL/egl.h>
+#include <EGL/eglext.h>
+#include <X11/Xatom.h>
+#include <X11/Xlib.h>
+#include <X11/Xutil.h>
+#include <X11/extensions/Xfixes.h>
+#include <X11/extensions/shape.h>
+
+#include <algorithm>
+#include <vector>
+
+extern "C" EGLBoolean __real_eglChooseConfig(EGLDisplay display, const EGLint* attributes, EGLConfig* configs, EGLint configSize, EGLint* configCount);
+
+namespace {
+
+class XDisplayConnection {
+public:
+    XDisplayConnection() : display(XOpenDisplay(nullptr)) {}
+
+    ~XDisplayConnection() {
+        if (display != nullptr) {
+            XCloseDisplay(display);
+        }
+    }
+
+    Display* get() const { return display; }
+
+private:
+    Display* display = nullptr;
+};
+
+Display* getDisplay() {
+    static XDisplayConnection connection;
+    return connection.get();
+}
+
+Window getWindow(const juce::Component& component) {
+    auto* peer = component.getPeer();
+    return peer != nullptr ? reinterpret_cast<Window>(peer->getNativeHandle()) : None;
+}
+
+bool hasExtension(Display* display, const char* name) {
+    int opcode = 0;
+    int firstEvent = 0;
+    int firstError = 0;
+    return display != nullptr && XQueryExtension(display, name, &opcode, &firstEvent, &firstError);
+}
+
+bool requestsAlpha(const EGLint* attributes) {
+    if (attributes == nullptr) {
+        return false;
+    }
+    for (auto* attribute = attributes; attribute[0] != EGL_NONE; attribute += 2) {
+        if (attribute[0] == EGL_ALPHA_SIZE) {
+            return attribute[1] > 0;
+        }
+    }
+    return false;
+}
+
+bool usesAlphaVisual(Display* display, EGLDisplay eglDisplay, EGLConfig config) {
+    EGLint visualId = 0;
+    if (display == nullptr
+        || eglGetConfigAttrib(eglDisplay, config, EGL_NATIVE_VISUAL_ID, &visualId) != EGL_TRUE) {
+        return false;
+    }
+
+    XVisualInfo visualTemplate{};
+    visualTemplate.visualid = static_cast<VisualID>(visualId);
+    int visualCount = 0;
+    auto* visuals = XGetVisualInfo(display, VisualIDMask, &visualTemplate, &visualCount);
+    const bool result = visuals != nullptr && visualCount > 0 && visuals[0].depth == 32;
+    if (visuals != nullptr) {
+        XFree(visuals);
+    }
+    return result;
+}
+
+bool supportsInputPassthrough(Display* display) {
+    static const bool supported = hasExtension(display, "XFIXES") && hasExtension(display, "SHAPE");
+    return supported;
+}
+
+bool hasCompatibleOpenGLVisual(Display* display) {
+    if (display == nullptr) {
+        return false;
+    }
+
+    auto eglDisplay = eglGetPlatformDisplay(EGL_PLATFORM_X11_KHR, display, nullptr);
+    if (eglDisplay == EGL_NO_DISPLAY || eglInitialize(eglDisplay, nullptr, nullptr) != EGL_TRUE) {
+        return false;
+    }
+
+    // Match JUCE's default OpenGLPixelFormat. A compositor-capable ARGB peer is
+    // not sufficient if JUCE's child EGL window would use an opaque X11 visual.
+    const EGLint attributes[] {
+        EGL_SURFACE_TYPE, EGL_WINDOW_BIT,
+        EGL_RENDERABLE_TYPE, EGL_OPENGL_BIT,
+        EGL_RED_SIZE, 8,
+        EGL_GREEN_SIZE, 8,
+        EGL_BLUE_SIZE, 8,
+        EGL_ALPHA_SIZE, 8,
+        EGL_DEPTH_SIZE, 16,
+        EGL_STENCIL_SIZE, 0,
+        EGL_SAMPLE_BUFFERS, 0,
+        EGL_SAMPLES, 0,
+        EGL_NONE,
+    };
+    EGLConfig config = nullptr;
+    EGLint configCount = 0;
+    const bool configFound = eglChooseConfig(eglDisplay, attributes, &config, 1, &configCount) == EGL_TRUE
+                          && configCount > 0;
+    EGLint visualId = 0;
+    const bool visualFound = configFound
+                          && eglGetConfigAttrib(eglDisplay, config, EGL_NATIVE_VISUAL_ID, &visualId) == EGL_TRUE;
+    eglTerminate(eglDisplay);
+    if (!visualFound) {
+        return false;
+    }
+
+    XVisualInfo visualTemplate{};
+    visualTemplate.visualid = static_cast<VisualID>(visualId);
+    int visualCount = 0;
+    auto* visuals = XGetVisualInfo(display, VisualIDMask, &visualTemplate, &visualCount);
+    const bool hasAlphaVisual = visuals != nullptr && visualCount > 0 && visuals[0].depth == 32;
+    if (visuals != nullptr) {
+        XFree(visuals);
+    }
+    return hasAlphaVisual;
+}
+
+bool windowHasState(Display* display, Window window, Atom requestedState) {
+    Atom type = None;
+    int format = 0;
+    unsigned long count = 0;
+    unsigned long remaining = 0;
+    unsigned char* data = nullptr;
+    const auto status = XGetWindowProperty(display, window, XInternAtom(display, "_NET_WM_STATE", False),
+                                           0, 64, False, XA_ATOM, &type, &format, &count, &remaining, &data);
+    if (status != Success || type != XA_ATOM || format != 32 || data == nullptr) {
+        if (data != nullptr) {
+            XFree(data);
+        }
+        return false;
+    }
+    const auto* states = reinterpret_cast<const Atom*>(data);
+    const bool result = std::find(states, states + count, requestedState) != states + count;
+    XFree(data);
+    return result;
+}
+
+void setWindowState(Display* display, Window window, const char* stateName, bool enabled) {
+    if (display == nullptr || window == None) {
+        return;
+    }
+
+    const auto state = XInternAtom(display, stateName, False);
+    if (windowHasState(display, window, state) == enabled) {
+        return;
+    }
+    XEvent event{};
+    event.xclient.type = ClientMessage;
+    event.xclient.window = window;
+    event.xclient.message_type = XInternAtom(display, "_NET_WM_STATE", False);
+    event.xclient.format = 32;
+    event.xclient.data.l[0] = enabled ? 1 : 0;
+    event.xclient.data.l[1] = static_cast<long>(state);
+    event.xclient.data.l[3] = 1;
+    XSendEvent(display, DefaultRootWindow(display), False,
+               SubstructureRedirectMask | SubstructureNotifyMask, &event);
+    XFlush(display);
+}
+
+void setInputPassthrough(Display* display, Window window, bool passthrough) {
+    if (display == nullptr || window == None || !supportsInputPassthrough(display)) {
+        return;
+    }
+
+    XserverRegion region = None;
+    if (passthrough) {
+        region = XFixesCreateRegion(display, nullptr, 0);
+    }
+    XFixesSetWindowShapeRegion(display, window, ShapeInput, 0, 0, region);
+    if (region != None) {
+        XFixesDestroyRegion(display, region);
+    }
+    XFlush(display);
+}
+
+void makeChildWindowsInputTransparent(Display* display, Window window) {
+    Window root = None;
+    Window parent = None;
+    Window* children = nullptr;
+    unsigned int childCount = 0;
+    if (display == nullptr || window == None
+        || XQueryTree(display, window, &root, &parent, &children, &childCount) == False) {
+        return;
+    }
+    for (unsigned int child = 0; child < childCount; ++child) {
+        setInputPassthrough(display, children[child], true);
+    }
+    if (children != nullptr) {
+        XFree(children);
+    }
+}
+
+bool isInputPassthrough(Display* display, Window window) {
+    if (display == nullptr || window == None || !supportsInputPassthrough(display)) {
+        return false;
+    }
+    int rectangleCount = 0;
+    int ordering = 0;
+    auto* rectangles = XShapeGetRectangles(display, window, ShapeInput, &rectangleCount, &ordering);
+    if (rectangles != nullptr) {
+        XFree(rectangles);
+    }
+    return rectangleCount == 0;
+}
+
+bool areChildWindowsInputTransparent(Display* display, Window window) {
+    Window root = None;
+    Window parent = None;
+    Window* children = nullptr;
+    unsigned int childCount = 0;
+    if (display == nullptr || window == None
+        || XQueryTree(display, window, &root, &parent, &children, &childCount) == False) {
+        return true;
+    }
+    bool result = true;
+    for (unsigned int child = 0; child < childCount; ++child) {
+        result = result && isInputPassthrough(display, children[child]);
+    }
+    if (children != nullptr) {
+        XFree(children);
+    }
+    return result;
+}
+
+juce::Rectangle<int> getDesktopWorkArea(Display* display) {
+    if (display == nullptr) {
+        return {};
+    }
+    Atom type = None;
+    int format = 0;
+    unsigned long count = 0;
+    unsigned long remaining = 0;
+    unsigned char* data = nullptr;
+    const auto status = XGetWindowProperty(display, DefaultRootWindow(display),
+                                           XInternAtom(display, "_NET_WORKAREA", False), 0, 4, False,
+                                           XA_CARDINAL, &type, &format, &count, &remaining, &data);
+    if (status != Success || type != XA_CARDINAL || format != 32 || count < 4 || data == nullptr) {
+        if (data != nullptr) {
+            XFree(data);
+        }
+        return {};
+    }
+    const auto* values = reinterpret_cast<const unsigned long*>(data);
+    const juce::Rectangle<int> result(static_cast<int>(values[0]), static_cast<int>(values[1]),
+                                      static_cast<int>(values[2]), static_cast<int>(values[3]));
+    XFree(data);
+    return result;
+}
+
+} // namespace
+
+// Mesa exposes both opaque and ARGB native visuals for otherwise identical RGBA
+// configs. JUCE accepts the first match, so prefer an actual depth-32 X11 visual.
+extern "C" EGLBoolean __wrap_eglChooseConfig(EGLDisplay eglDisplay, const EGLint* attributes, EGLConfig* configs, EGLint configSize, EGLint* configCount) {
+    if (configs == nullptr || configSize <= 0 || !requestsAlpha(attributes)) {
+        return __real_eglChooseConfig(eglDisplay, attributes, configs, configSize, configCount);
+    }
+
+    EGLint matchCount = 0;
+    if (__real_eglChooseConfig(eglDisplay, attributes, nullptr, 0, &matchCount) != EGL_TRUE || matchCount <= 0) {
+        return __real_eglChooseConfig(eglDisplay, attributes, configs, configSize, configCount);
+    }
+
+    std::vector<EGLConfig> matches(static_cast<std::size_t>(matchCount));
+    if (__real_eglChooseConfig(eglDisplay, attributes, matches.data(), matchCount, &matchCount) != EGL_TRUE) {
+        return EGL_FALSE;
+    }
+
+    auto alphaConfig = std::find_if(matches.begin(), matches.end(), [eglDisplay](EGLConfig config) {
+        return usesAlphaVisual(getDisplay(), eglDisplay, config);
+    });
+    if (alphaConfig != matches.end()) {
+        std::rotate(matches.begin(), alphaConfig, std::next(alphaConfig));
+    }
+
+    const auto copyCount = juce::jmin(configSize, matchCount);
+    std::copy_n(matches.begin(), copyCount, configs);
+    if (configCount != nullptr) {
+        *configCount = matchCount;
+    }
+    return EGL_TRUE;
+}
+
+bool TransparentWindow::isTransparencySupported() {
+    static const bool supported = juce::Desktop::canUseSemiTransparentWindows()
+                               && hasCompatibleOpenGLVisual(getDisplay());
+    return supported;
+}
+
+bool TransparentWindow::supportsClickThroughInTransparentFullScreen() {
+    return supportsInputPassthrough(getDisplay());
+}
+
+juce::Rectangle<int> TransparentWindow::getTransparentFullScreenBounds(juce::Rectangle<int> displayBounds) {
+    const auto workArea = getDesktopWorkArea(getDisplay());
+    const auto usableDisplay = displayBounds.getIntersection(workArea);
+    return usableDisplay.isEmpty() ? displayBounds : usableDisplay;
+}
+
+void TransparentWindow::configureNativeTransparency() {
+    auto* display = getDisplay();
+    const auto window = getWindow(*this);
+    if (display == nullptr || window == None) {
+        return;
+    }
+
+    const auto bypassCompositor = XInternAtom(display, "_NET_WM_BYPASS_COMPOSITOR", False);
+    const unsigned long forceCompositing = 2;
+    XChangeProperty(display, window, bypassCompositor, XA_CARDINAL, 32, PropModeReplace,
+                    reinterpret_cast<const unsigned char*>(&forceCompositing), 1);
+    if (transparencyEnabled) {
+        // Mutter promotes an undecorated display-sized window to EWMH fullscreen.
+        // Keep transparent fullscreen as an ordinary composited window instead.
+        setWindowState(display, window, "_NET_WM_STATE_FULLSCREEN", false);
+    }
+    // JUCE's EGL surface is a native child that otherwise intercepts events
+    // before the parent peer can route them to the composited toolbar.
+    makeChildWindowsInputTransparent(display, window);
+    setWindowState(display, window, "_NET_WM_STATE_ABOVE", pinned);
+    setInputPassthrough(display, window, nativeIgnoresMouseEvents);
+    XFlush(display);
+}
+
+void TransparentWindow::setNativeIgnoresMouseEvents(bool ignoresMouseEvents) {
+    auto* display = getDisplay();
+    const auto window = getWindow(*this);
+    makeChildWindowsInputTransparent(display, window);
+    setInputPassthrough(display, window, ignoresMouseEvents);
+}
+
+bool TransparentWindow::isNativeMouseInteractionStateApplied(bool ignoresMouseEvents) const {
+    auto* display = getDisplay();
+    const auto window = getWindow(*this);
+    return isInputPassthrough(display, window) == ignoresMouseEvents
+        && areChildWindowsInputTransparent(display, window);
+}
+
+void TransparentWindow::setNativeAlwaysOnTop(bool alwaysOnTop) {
+    setWindowState(getDisplay(), getWindow(*this), "_NET_WM_STATE_ABOVE", alwaysOnTop);
+}
+
+bool TransparentWindow::isNativeFullScreenStateActive() const {
+    auto* display = getDisplay();
+    const auto window = getWindow(*this);
+    return display != nullptr && window != None
+        && windowHasState(display, window, XInternAtom(display, "_NET_WM_STATE_FULLSCREEN", False));
+}
+
+void TransparentWindow::setMovesToActiveSpace(bool) {}
+void TransparentWindow::setNativeRoundedWindowRegion(float) {}
+
+void TransparentWindow::setNativeBounds(juce::Rectangle<int> bounds) {
+    auto* display = getDisplay();
+    const auto window = getWindow(*this);
+    if (display == nullptr || window == None) {
+        return;
+    }
+    XMoveResizeWindow(display, window, bounds.getX(), bounds.getY(),
+                      static_cast<unsigned int>(bounds.getWidth()),
+                      static_cast<unsigned int>(bounds.getHeight()));
+    XFlush(display);
+}
+
+void TransparentWindow::configureOpenGLSurface(void*) {}
+
+#endif

--- a/Source/visualiser/TransparentWindow_linux.cpp
+++ b/Source/visualiser/TransparentWindow_linux.cpp
@@ -6,10 +6,13 @@
 #include <X11/Xatom.h>
 #include <X11/Xlib.h>
 #include <X11/Xutil.h>
+#include <X11/extensions/Xrender.h>
 #include <X11/extensions/Xfixes.h>
 #include <X11/extensions/shape.h>
 
 #include <algorithm>
+#include <atomic>
+#include <cmath>
 #include <vector>
 
 extern "C" EGLBoolean __real_eglChooseConfig(EGLDisplay display, const EGLint* attributes, EGLConfig* configs, EGLint configSize, EGLint* configCount);
@@ -49,6 +52,11 @@ bool hasExtension(Display* display, const char* name) {
     return display != nullptr && XQueryExtension(display, name, &opcode, &firstEvent, &firstError);
 }
 
+std::atomic<VisualID>& getAlphaVisualId() {
+    static std::atomic<VisualID> id{ 0 };
+    return id;
+}
+
 bool requestsAlpha(const EGLint* attributes) {
     if (attributes == nullptr) {
         return false;
@@ -61,22 +69,16 @@ bool requestsAlpha(const EGLint* attributes) {
     return false;
 }
 
-bool usesAlphaVisual(Display* display, EGLDisplay eglDisplay, EGLConfig config) {
+VisualID getVisualId(EGLDisplay eglDisplay, EGLConfig config) {
     EGLint visualId = 0;
-    if (display == nullptr
-        || eglGetConfigAttrib(eglDisplay, config, EGL_NATIVE_VISUAL_ID, &visualId) != EGL_TRUE) {
-        return false;
+    if (eglGetConfigAttrib(eglDisplay, config, EGL_NATIVE_VISUAL_ID, &visualId) != EGL_TRUE) {
+        return 0;
     }
+    return static_cast<VisualID>(visualId);
+}
 
-    XVisualInfo visualTemplate{};
-    visualTemplate.visualid = static_cast<VisualID>(visualId);
-    int visualCount = 0;
-    auto* visuals = XGetVisualInfo(display, VisualIDMask, &visualTemplate, &visualCount);
-    const bool result = visuals != nullptr && visualCount > 0 && visuals[0].depth == 32;
-    if (visuals != nullptr) {
-        XFree(visuals);
-    }
-    return result;
+bool usesAlphaVisual(EGLDisplay eglDisplay, EGLConfig config) {
+    return getVisualId(eglDisplay, config) == getAlphaVisualId().load(std::memory_order_acquire);
 }
 
 bool supportsInputPassthrough(Display* display) {
@@ -109,27 +111,42 @@ bool hasCompatibleOpenGLVisual(Display* display) {
         EGL_SAMPLES, 0,
         EGL_NONE,
     };
-    EGLConfig config = nullptr;
     EGLint configCount = 0;
-    const bool configFound = eglChooseConfig(eglDisplay, attributes, &config, 1, &configCount) == EGL_TRUE
-                          && configCount > 0;
-    EGLint visualId = 0;
-    const bool visualFound = configFound
-                          && eglGetConfigAttrib(eglDisplay, config, EGL_NATIVE_VISUAL_ID, &visualId) == EGL_TRUE;
-    eglTerminate(eglDisplay);
-    if (!visualFound) {
+    if (__real_eglChooseConfig(eglDisplay, attributes, nullptr, 0, &configCount) != EGL_TRUE || configCount <= 0) {
+        eglTerminate(eglDisplay);
         return false;
     }
 
-    XVisualInfo visualTemplate{};
-    visualTemplate.visualid = static_cast<VisualID>(visualId);
-    int visualCount = 0;
-    auto* visuals = XGetVisualInfo(display, VisualIDMask, &visualTemplate, &visualCount);
-    const bool hasAlphaVisual = visuals != nullptr && visualCount > 0 && visuals[0].depth == 32;
-    if (visuals != nullptr) {
-        XFree(visuals);
+    std::vector<EGLConfig> configs(static_cast<std::size_t>(configCount));
+    if (__real_eglChooseConfig(eglDisplay, attributes, configs.data(), configCount, &configCount) != EGL_TRUE) {
+        eglTerminate(eglDisplay);
+        return false;
     }
-    return hasAlphaVisual;
+    configs.resize(static_cast<std::size_t>(configCount));
+
+    for (const auto config : configs) {
+        const auto visualId = getVisualId(eglDisplay, config);
+        XVisualInfo visualTemplate{};
+        visualTemplate.visualid = visualId;
+        int visualCount = 0;
+        auto* visuals = XGetVisualInfo(display, VisualIDMask, &visualTemplate, &visualCount);
+        bool foundAlphaVisual = false;
+        if (visuals != nullptr && visualCount > 0) {
+            const auto* format = XRenderFindVisualFormat(display, visuals[0].visual);
+            if (format != nullptr && format->type == PictTypeDirect && format->direct.alphaMask != 0) {
+                getAlphaVisualId().store(visualId, std::memory_order_release);
+                foundAlphaVisual = true;
+            }
+        }
+        if (visuals != nullptr) {
+            XFree(visuals);
+        }
+        if (foundAlphaVisual) {
+            break;
+        }
+    }
+    eglTerminate(eglDisplay);
+    return getAlphaVisualId().load(std::memory_order_acquire) != 0;
 }
 
 bool windowHasState(Display* display, Window window, Atom requestedState) {
@@ -158,9 +175,6 @@ void setWindowState(Display* display, Window window, const char* stateName, bool
     }
 
     const auto state = XInternAtom(display, stateName, False);
-    if (windowHasState(display, window, state) == enabled) {
-        return;
-    }
     XEvent event{};
     event.xclient.type = ClientMessage;
     event.xclient.window = window;
@@ -171,7 +185,6 @@ void setWindowState(Display* display, Window window, const char* stateName, bool
     event.xclient.data.l[3] = 1;
     XSendEvent(display, DefaultRootWindow(display), False,
                SubstructureRedirectMask | SubstructureNotifyMask, &event);
-    XFlush(display);
 }
 
 void setInputPassthrough(Display* display, Window window, bool passthrough) {
@@ -187,7 +200,6 @@ void setInputPassthrough(Display* display, Window window, bool passthrough) {
     if (region != None) {
         XFixesDestroyRegion(display, region);
     }
-    XFlush(display);
 }
 
 void makeChildWindowsInputTransparent(Display* display, Window window) {
@@ -207,51 +219,32 @@ void makeChildWindowsInputTransparent(Display* display, Window window) {
     }
 }
 
-bool isInputPassthrough(Display* display, Window window) {
-    if (display == nullptr || window == None || !supportsInputPassthrough(display)) {
-        return false;
-    }
-    int rectangleCount = 0;
-    int ordering = 0;
-    auto* rectangles = XShapeGetRectangles(display, window, ShapeInput, &rectangleCount, &ordering);
-    if (rectangles != nullptr) {
-        XFree(rectangles);
-    }
-    return rectangleCount == 0;
-}
-
-bool areChildWindowsInputTransparent(Display* display, Window window) {
-    Window root = None;
-    Window parent = None;
-    Window* children = nullptr;
-    unsigned int childCount = 0;
-    if (display == nullptr || window == None
-        || XQueryTree(display, window, &root, &parent, &children, &childCount) == False) {
-        return true;
-    }
-    bool result = true;
-    for (unsigned int child = 0; child < childCount; ++child) {
-        result = result && isInputPassthrough(display, children[child]);
-    }
-    if (children != nullptr) {
-        XFree(children);
-    }
-    return result;
-}
-
 juce::Rectangle<int> getDesktopWorkArea(Display* display) {
     if (display == nullptr) {
         return {};
     }
+
+    const auto root = DefaultRootWindow(display);
+    unsigned long desktop = 0;
+    unsigned char* data = nullptr;
     Atom type = None;
     int format = 0;
     unsigned long count = 0;
     unsigned long remaining = 0;
-    unsigned char* data = nullptr;
-    const auto status = XGetWindowProperty(display, DefaultRootWindow(display),
-                                           XInternAtom(display, "_NET_WORKAREA", False), 0, 4, False,
-                                           XA_CARDINAL, &type, &format, &count, &remaining, &data);
-    if (status != Success || type != XA_CARDINAL || format != 32 || count < 4 || data == nullptr) {
+    if (XGetWindowProperty(display, root, XInternAtom(display, "_NET_CURRENT_DESKTOP", False), 0, 1, False,
+                           XA_CARDINAL, &type, &format, &count, &remaining, &data) == Success
+        && type == XA_CARDINAL && format == 32 && count == 1 && data != nullptr) {
+        desktop = *reinterpret_cast<unsigned long*>(data);
+    }
+    if (data != nullptr) {
+        XFree(data);
+        data = nullptr;
+    }
+
+    const auto offset = static_cast<long>(desktop * 4);
+    if (XGetWindowProperty(display, root, XInternAtom(display, "_NET_WORKAREA", False), offset, 4, False,
+                           XA_CARDINAL, &type, &format, &count, &remaining, &data) != Success
+        || type != XA_CARDINAL || format != 32 || count != 4 || data == nullptr) {
         if (data != nullptr) {
             XFree(data);
         }
@@ -282,9 +275,10 @@ extern "C" EGLBoolean __wrap_eglChooseConfig(EGLDisplay eglDisplay, const EGLint
     if (__real_eglChooseConfig(eglDisplay, attributes, matches.data(), matchCount, &matchCount) != EGL_TRUE) {
         return EGL_FALSE;
     }
+    matches.resize(static_cast<std::size_t>(matchCount));
 
     auto alphaConfig = std::find_if(matches.begin(), matches.end(), [eglDisplay](EGLConfig config) {
-        return usesAlphaVisual(getDisplay(), eglDisplay, config);
+        return usesAlphaVisual(eglDisplay, config);
     });
     if (alphaConfig != matches.end()) {
         std::rotate(matches.begin(), alphaConfig, std::next(alphaConfig));
@@ -293,13 +287,14 @@ extern "C" EGLBoolean __wrap_eglChooseConfig(EGLDisplay eglDisplay, const EGLint
     const auto copyCount = juce::jmin(configSize, matchCount);
     std::copy_n(matches.begin(), copyCount, configs);
     if (configCount != nullptr) {
-        *configCount = matchCount;
+        *configCount = copyCount;
     }
     return EGL_TRUE;
 }
 
 bool TransparentWindow::isTransparencySupported() {
     static const bool supported = juce::Desktop::canUseSemiTransparentWindows()
+                               && supportsInputPassthrough(getDisplay())
                                && hasCompatibleOpenGLVisual(getDisplay());
     return supported;
 }
@@ -309,9 +304,15 @@ bool TransparentWindow::supportsClickThroughInTransparentFullScreen() {
 }
 
 juce::Rectangle<int> TransparentWindow::getTransparentFullScreenBounds(juce::Rectangle<int> displayBounds) {
+    auto& displays = juce::Desktop::getInstance().getDisplays();
+    auto* display = displays.getDisplayForRect(displayBounds);
     const auto workArea = getDesktopWorkArea(getDisplay());
-    const auto usableDisplay = displayBounds.getIntersection(workArea);
-    return usableDisplay.isEmpty() ? displayBounds : usableDisplay;
+    if (display == nullptr || workArea.isEmpty()) {
+        return displayBounds;
+    }
+    const auto physicalDisplay = displays.logicalToPhysical(displayBounds, display);
+    const auto usablePhysical = physicalDisplay.getIntersection(workArea);
+    return usablePhysical.isEmpty() ? displayBounds : displays.physicalToLogical(usablePhysical, display);
 }
 
 void TransparentWindow::configureNativeTransparency() {
@@ -330,30 +331,35 @@ void TransparentWindow::configureNativeTransparency() {
         // Keep transparent fullscreen as an ordinary composited window instead.
         setWindowState(display, window, "_NET_WM_STATE_FULLSCREEN", false);
     }
-    // JUCE's EGL surface is a native child that otherwise intercepts events
-    // before the parent peer can route them to the composited toolbar.
-    makeChildWindowsInputTransparent(display, window);
     setWindowState(display, window, "_NET_WM_STATE_ABOVE", pinned);
-    setInputPassthrough(display, window, nativeIgnoresMouseEvents);
-    XFlush(display);
+    setNativeIgnoresMouseEvents(nativeIgnoresMouseEvents);
 }
 
 void TransparentWindow::setNativeIgnoresMouseEvents(bool ignoresMouseEvents) {
     auto* display = getDisplay();
     const auto window = getWindow(*this);
+    if (display == nullptr || window == None) {
+        return;
+    }
+
+    // Prevent the EGL child from disappearing between discovery and shaping.
+    XGrabServer(display);
     makeChildWindowsInputTransparent(display, window);
     setInputPassthrough(display, window, ignoresMouseEvents);
+    XUngrabServer(display);
+    XFlush(display);
 }
 
 bool TransparentWindow::isNativeMouseInteractionStateApplied(bool ignoresMouseEvents) const {
-    auto* display = getDisplay();
-    const auto window = getWindow(*this);
-    return isInputPassthrough(display, window) == ignoresMouseEvents
-        && areChildWindowsInputTransparent(display, window);
+    return nativeIgnoresMouseEvents == ignoresMouseEvents;
 }
 
 void TransparentWindow::setNativeAlwaysOnTop(bool alwaysOnTop) {
-    setWindowState(getDisplay(), getWindow(*this), "_NET_WM_STATE_ABOVE", alwaysOnTop);
+    auto* display = getDisplay();
+    setWindowState(display, getWindow(*this), "_NET_WM_STATE_ABOVE", alwaysOnTop);
+    if (display != nullptr) {
+        XFlush(display);
+    }
 }
 
 bool TransparentWindow::isNativeFullScreenStateActive() const {
@@ -364,7 +370,43 @@ bool TransparentWindow::isNativeFullScreenStateActive() const {
 }
 
 void TransparentWindow::setMovesToActiveSpace(bool) {}
-void TransparentWindow::setNativeRoundedWindowRegion(float) {}
+
+void TransparentWindow::setNativeRoundedWindowRegion(float radius) {
+    auto* display = getDisplay();
+    const auto window = getWindow(*this);
+    if (display == nullptr || window == None || !supportsInputPassthrough(display)) {
+        return;
+    }
+    if (radius <= 0.0f) {
+        XFixesSetWindowShapeRegion(display, window, ShapeBounding, 0, 0, None);
+        XFlush(display);
+        return;
+    }
+
+    XWindowAttributes attributes{};
+    if (XGetWindowAttributes(display, window, &attributes) == False) {
+        return;
+    }
+    const auto scale = getPeer() != nullptr ? static_cast<float>(getPeer()->getPlatformScaleFactor()) : 1.0f;
+    const int scaledRadius = juce::jlimit(1, juce::jmin(attributes.width, attributes.height) / 2,
+                                          juce::roundToInt(radius * scale));
+    std::vector<XRectangle> rectangles;
+    rectangles.reserve(static_cast<std::size_t>(scaledRadius * 2 + 1));
+    rectangles.push_back({ 0, static_cast<short>(scaledRadius), static_cast<unsigned short>(attributes.width),
+                           static_cast<unsigned short>(juce::jmax(0, attributes.height - scaledRadius * 2)) });
+    for (int y = 0; y < scaledRadius; ++y) {
+        const auto dy = static_cast<double>(scaledRadius - y) - 0.5;
+        const int inset = juce::roundToInt(static_cast<double>(scaledRadius)
+                                          - std::sqrt(static_cast<double>(scaledRadius * scaledRadius) - dy * dy));
+        const auto width = static_cast<unsigned short>(juce::jmax(0, attributes.width - inset * 2));
+        rectangles.push_back({ static_cast<short>(inset), static_cast<short>(y), width, 1 });
+        rectangles.push_back({ static_cast<short>(inset), static_cast<short>(attributes.height - y - 1), width, 1 });
+    }
+    const auto region = XFixesCreateRegion(display, rectangles.data(), static_cast<int>(rectangles.size()));
+    XFixesSetWindowShapeRegion(display, window, ShapeBounding, 0, 0, region);
+    XFixesDestroyRegion(display, region);
+    XFlush(display);
+}
 
 void TransparentWindow::setNativeBounds(juce::Rectangle<int> bounds) {
     auto* display = getDisplay();
@@ -372,9 +414,12 @@ void TransparentWindow::setNativeBounds(juce::Rectangle<int> bounds) {
     if (display == nullptr || window == None) {
         return;
     }
-    XMoveResizeWindow(display, window, bounds.getX(), bounds.getY(),
-                      static_cast<unsigned int>(bounds.getWidth()),
-                      static_cast<unsigned int>(bounds.getHeight()));
+    auto& displays = juce::Desktop::getInstance().getDisplays();
+    auto* targetDisplay = displays.getDisplayForRect(bounds);
+    const auto physicalBounds = displays.logicalToPhysical(bounds, targetDisplay);
+    XMoveResizeWindow(display, window, physicalBounds.getX(), physicalBounds.getY(),
+                      static_cast<unsigned int>(physicalBounds.getWidth()),
+                      static_cast<unsigned int>(physicalBounds.getHeight()));
     XFlush(display);
 }
 

--- a/Source/visualiser/TransparentWindow_linux.cpp
+++ b/Source/visualiser/TransparentWindow_linux.cpp
@@ -1,38 +1,17 @@
 #include "TransparentWindow.h"
+#include "OpenGL_linux.h"
 
 #if JUCE_LINUX
-#include <EGL/egl.h>
-#include <EGL/eglext.h>
 #include <X11/Xatom.h>
 #include <X11/Xlib.h>
-#include <X11/Xutil.h>
-#include <X11/extensions/Xrender.h>
 #include <X11/extensions/shape.h>
 
 #include <algorithm>
-#include <atomic>
 #include <cmath>
-#include <map>
 #include <memory>
-#include <mutex>
 #include <vector>
 
-extern "C" EGLBoolean __real_eglChooseConfig(EGLDisplay display, const EGLint* attributes, EGLConfig* configs, EGLint configSize, EGLint* configCount);
-extern "C" EGLBoolean __real_eglInitialize(EGLDisplay display, EGLint* major, EGLint* minor);
-extern "C" EGLBoolean __real_eglTerminate(EGLDisplay display);
-
 namespace {
-
-struct EGLDisplayReferences {
-    // Initialisation and termination may block inside the driver.
-    std::mutex mutex;
-    std::map<EGLDisplay, unsigned int> counts;
-};
-
-EGLDisplayReferences& getEGLDisplayReferences() {
-    static EGLDisplayReferences references;
-    return references;
-}
 
 Display* getDisplay() {
     static const std::unique_ptr<Display, decltype(&XCloseDisplay)> display(XOpenDisplay(nullptr), XCloseDisplay);
@@ -44,35 +23,6 @@ Window getWindow(const juce::Component& component) {
     return peer != nullptr ? reinterpret_cast<Window>(peer->getNativeHandle()) : None;
 }
 
-std::atomic<VisualID>& getAlphaVisualId() {
-    static std::atomic<VisualID> id{ 0 };
-    return id;
-}
-
-bool requestsAlpha(const EGLint* attributes) {
-    if (attributes == nullptr) {
-        return false;
-    }
-    for (auto* attribute = attributes; attribute[0] != EGL_NONE; attribute += 2) {
-        if (attribute[0] == EGL_ALPHA_SIZE) {
-            return attribute[1] > 0;
-        }
-    }
-    return false;
-}
-
-VisualID getVisualId(EGLDisplay eglDisplay, EGLConfig config) {
-    EGLint visualId = 0;
-    if (eglGetConfigAttrib(eglDisplay, config, EGL_NATIVE_VISUAL_ID, &visualId) != EGL_TRUE) {
-        return 0;
-    }
-    return static_cast<VisualID>(visualId);
-}
-
-bool usesAlphaVisual(EGLDisplay eglDisplay, EGLConfig config) {
-    return getVisualId(eglDisplay, config) == getAlphaVisualId().load(std::memory_order_acquire);
-}
-
 bool supportsInputPassthrough(Display* display) {
     static const bool supported = [display] {
         int major = 0;
@@ -81,69 +31,6 @@ bool supportsInputPassthrough(Display* display) {
             && (major > 1 || (major == 1 && minor >= 1));
     }();
     return supported;
-}
-
-bool hasCompatibleOpenGLVisual(Display* display) {
-    if (display == nullptr) {
-        return false;
-    }
-
-    auto eglDisplay = eglGetPlatformDisplay(EGL_PLATFORM_X11_KHR, display, nullptr);
-    if (eglDisplay == EGL_NO_DISPLAY || eglInitialize(eglDisplay, nullptr, nullptr) != EGL_TRUE) {
-        return false;
-    }
-
-    // Match JUCE's default OpenGLPixelFormat. A compositor-capable ARGB peer is
-    // not sufficient if JUCE's child EGL window would use an opaque X11 visual.
-    const EGLint attributes[] {
-        EGL_SURFACE_TYPE, EGL_WINDOW_BIT,
-        EGL_RENDERABLE_TYPE, EGL_OPENGL_BIT,
-        EGL_RED_SIZE, 8,
-        EGL_GREEN_SIZE, 8,
-        EGL_BLUE_SIZE, 8,
-        EGL_ALPHA_SIZE, 8,
-        EGL_DEPTH_SIZE, 16,
-        EGL_STENCIL_SIZE, 0,
-        EGL_SAMPLE_BUFFERS, 0,
-        EGL_SAMPLES, 0,
-        EGL_NONE,
-    };
-    EGLint configCount = 0;
-    if (__real_eglChooseConfig(eglDisplay, attributes, nullptr, 0, &configCount) != EGL_TRUE || configCount <= 0) {
-        eglTerminate(eglDisplay);
-        return false;
-    }
-
-    std::vector<EGLConfig> configs(static_cast<std::size_t>(configCount));
-    if (__real_eglChooseConfig(eglDisplay, attributes, configs.data(), configCount, &configCount) != EGL_TRUE) {
-        eglTerminate(eglDisplay);
-        return false;
-    }
-    configs.resize(static_cast<std::size_t>(configCount));
-
-    for (const auto config : configs) {
-        const auto visualId = getVisualId(eglDisplay, config);
-        XVisualInfo visualTemplate{};
-        visualTemplate.visualid = visualId;
-        int visualCount = 0;
-        auto* visuals = XGetVisualInfo(display, VisualIDMask, &visualTemplate, &visualCount);
-        bool foundAlphaVisual = false;
-        if (visuals != nullptr && visualCount > 0) {
-            const auto* format = XRenderFindVisualFormat(display, visuals[0].visual);
-            if (format != nullptr && format->type == PictTypeDirect && format->direct.alphaMask != 0) {
-                getAlphaVisualId().store(visualId, std::memory_order_release);
-                foundAlphaVisual = true;
-            }
-        }
-        if (visuals != nullptr) {
-            XFree(visuals);
-        }
-        if (foundAlphaVisual) {
-            break;
-        }
-    }
-    eglTerminate(eglDisplay);
-    return getAlphaVisualId().load(std::memory_order_acquire) != 0;
 }
 
 bool windowHasState(Display* display, Window window, Atom requestedState) {
@@ -253,68 +140,10 @@ juce::Rectangle<int> getDesktopWorkArea(Display* display) {
 
 } // namespace
 
-// JUCE initialises/terminates the same EGL display for each OpenGL context.
-// EGL does not count these calls: hiding one visualiser would otherwise destroy
-// the editor's surfaces too. Terminate only when the last context releases it.
-extern "C" EGLBoolean __wrap_eglInitialize(EGLDisplay display, EGLint* major, EGLint* minor) {
-    auto& references = getEGLDisplayReferences();
-    const std::lock_guard<std::mutex> lock(references.mutex);
-    const auto result = __real_eglInitialize(display, major, minor);
-    if (result == EGL_TRUE) {
-        ++references.counts[display];
-    }
-    return result;
-}
-
-extern "C" EGLBoolean __wrap_eglTerminate(EGLDisplay display) {
-    auto& references = getEGLDisplayReferences();
-    const std::lock_guard<std::mutex> lock(references.mutex);
-    const auto entry = references.counts.find(display);
-    if (entry != references.counts.end()) {
-        if (--entry->second != 0) {
-            return EGL_TRUE;
-        }
-        references.counts.erase(entry);
-    }
-    return __real_eglTerminate(display);
-}
-
-// Mesa exposes both opaque and ARGB native visuals for otherwise identical RGBA
-// configs. JUCE accepts the first match, so prefer an actual depth-32 X11 visual.
-extern "C" EGLBoolean __wrap_eglChooseConfig(EGLDisplay eglDisplay, const EGLint* attributes, EGLConfig* configs, EGLint configSize, EGLint* configCount) {
-    if (configs == nullptr || configSize <= 0 || configCount == nullptr || !requestsAlpha(attributes)
-        || getAlphaVisualId().load(std::memory_order_acquire) == 0) {
-        return __real_eglChooseConfig(eglDisplay, attributes, configs, configSize, configCount);
-    }
-
-    EGLint matchCount = 0;
-    if (__real_eglChooseConfig(eglDisplay, attributes, nullptr, 0, &matchCount) != EGL_TRUE || matchCount <= 0) {
-        return __real_eglChooseConfig(eglDisplay, attributes, configs, configSize, configCount);
-    }
-
-    std::vector<EGLConfig> matches(static_cast<std::size_t>(matchCount));
-    if (__real_eglChooseConfig(eglDisplay, attributes, matches.data(), matchCount, &matchCount) != EGL_TRUE) {
-        return EGL_FALSE;
-    }
-    matches.resize(static_cast<std::size_t>(matchCount));
-
-    auto alphaConfig = std::find_if(matches.begin(), matches.end(), [eglDisplay](EGLConfig config) {
-        return usesAlphaVisual(eglDisplay, config);
-    });
-    if (alphaConfig != matches.end()) {
-        std::rotate(matches.begin(), alphaConfig, std::next(alphaConfig));
-    }
-
-    const auto copyCount = juce::jmin(configSize, matchCount);
-    std::copy_n(matches.begin(), copyCount, configs);
-    *configCount = copyCount;
-    return EGL_TRUE;
-}
-
 bool TransparentWindow::isTransparencySupported() {
     static const bool supported = juce::Desktop::canUseSemiTransparentWindows()
                                && supportsInputPassthrough(getDisplay())
-                               && hasCompatibleOpenGLVisual(getDisplay());
+                               && osci::hasCompatibleOpenGLVisual(getDisplay());
     return supported;
 }
 

--- a/Source/visualiser/TransparentWindow_linux.cpp
+++ b/Source/visualiser/TransparentWindow_linux.cpp
@@ -12,12 +12,27 @@
 #include <algorithm>
 #include <atomic>
 #include <cmath>
+#include <map>
 #include <memory>
+#include <mutex>
 #include <vector>
 
 extern "C" EGLBoolean __real_eglChooseConfig(EGLDisplay display, const EGLint* attributes, EGLConfig* configs, EGLint configSize, EGLint* configCount);
+extern "C" EGLBoolean __real_eglInitialize(EGLDisplay display, EGLint* major, EGLint* minor);
+extern "C" EGLBoolean __real_eglTerminate(EGLDisplay display);
 
 namespace {
+
+struct EGLDisplayReferences {
+    // Initialisation and termination may block inside the driver.
+    std::mutex mutex;
+    std::map<EGLDisplay, unsigned int> counts;
+};
+
+EGLDisplayReferences& getEGLDisplayReferences() {
+    static EGLDisplayReferences references;
+    return references;
+}
 
 Display* getDisplay() {
     static const std::unique_ptr<Display, decltype(&XCloseDisplay)> display(XOpenDisplay(nullptr), XCloseDisplay);
@@ -237,6 +252,32 @@ juce::Rectangle<int> getDesktopWorkArea(Display* display) {
 }
 
 } // namespace
+
+// JUCE initialises/terminates the same EGL display for each OpenGL context.
+// EGL does not count these calls: hiding one visualiser would otherwise destroy
+// the editor's surfaces too. Terminate only when the last context releases it.
+extern "C" EGLBoolean __wrap_eglInitialize(EGLDisplay display, EGLint* major, EGLint* minor) {
+    auto& references = getEGLDisplayReferences();
+    const std::lock_guard<std::mutex> lock(references.mutex);
+    const auto result = __real_eglInitialize(display, major, minor);
+    if (result == EGL_TRUE) {
+        ++references.counts[display];
+    }
+    return result;
+}
+
+extern "C" EGLBoolean __wrap_eglTerminate(EGLDisplay display) {
+    auto& references = getEGLDisplayReferences();
+    const std::lock_guard<std::mutex> lock(references.mutex);
+    const auto entry = references.counts.find(display);
+    if (entry != references.counts.end()) {
+        if (--entry->second != 0) {
+            return EGL_TRUE;
+        }
+        references.counts.erase(entry);
+    }
+    return __real_eglTerminate(display);
+}
 
 // Mesa exposes both opaque and ARGB native visuals for otherwise identical RGBA
 // configs. JUCE accepts the first match, so prefer an actual depth-32 X11 visual.

--- a/Source/visualiser/TransparentWindow_linux.cpp
+++ b/Source/visualiser/TransparentWindow_linux.cpp
@@ -7,49 +7,26 @@
 #include <X11/Xlib.h>
 #include <X11/Xutil.h>
 #include <X11/extensions/Xrender.h>
-#include <X11/extensions/Xfixes.h>
 #include <X11/extensions/shape.h>
 
 #include <algorithm>
 #include <atomic>
 #include <cmath>
+#include <memory>
 #include <vector>
 
 extern "C" EGLBoolean __real_eglChooseConfig(EGLDisplay display, const EGLint* attributes, EGLConfig* configs, EGLint configSize, EGLint* configCount);
 
 namespace {
 
-class XDisplayConnection {
-public:
-    XDisplayConnection() : display(XOpenDisplay(nullptr)) {}
-
-    ~XDisplayConnection() {
-        if (display != nullptr) {
-            XCloseDisplay(display);
-        }
-    }
-
-    Display* get() const { return display; }
-
-private:
-    Display* display = nullptr;
-};
-
 Display* getDisplay() {
-    static XDisplayConnection connection;
-    return connection.get();
+    static const std::unique_ptr<Display, decltype(&XCloseDisplay)> display(XOpenDisplay(nullptr), XCloseDisplay);
+    return display.get();
 }
 
 Window getWindow(const juce::Component& component) {
     auto* peer = component.getPeer();
     return peer != nullptr ? reinterpret_cast<Window>(peer->getNativeHandle()) : None;
-}
-
-bool hasExtension(Display* display, const char* name) {
-    int opcode = 0;
-    int firstEvent = 0;
-    int firstError = 0;
-    return display != nullptr && XQueryExtension(display, name, &opcode, &firstEvent, &firstError);
 }
 
 std::atomic<VisualID>& getAlphaVisualId() {
@@ -82,7 +59,12 @@ bool usesAlphaVisual(EGLDisplay eglDisplay, EGLConfig config) {
 }
 
 bool supportsInputPassthrough(Display* display) {
-    static const bool supported = hasExtension(display, "XFIXES") && hasExtension(display, "SHAPE");
+    static const bool supported = [display] {
+        int major = 0;
+        int minor = 0;
+        return display != nullptr && XShapeQueryVersion(display, &major, &minor)
+            && (major > 1 || (major == 1 && minor >= 1));
+    }();
     return supported;
 }
 
@@ -192,13 +174,10 @@ void setInputPassthrough(Display* display, Window window, bool passthrough) {
         return;
     }
 
-    XserverRegion region = None;
     if (passthrough) {
-        region = XFixesCreateRegion(display, nullptr, 0);
-    }
-    XFixesSetWindowShapeRegion(display, window, ShapeInput, 0, 0, region);
-    if (region != None) {
-        XFixesDestroyRegion(display, region);
+        XShapeCombineRectangles(display, window, ShapeInput, 0, 0, nullptr, 0, ShapeSet, Unsorted);
+    } else {
+        XShapeCombineMask(display, window, ShapeInput, 0, 0, None, ShapeSet);
     }
 }
 
@@ -262,7 +241,8 @@ juce::Rectangle<int> getDesktopWorkArea(Display* display) {
 // Mesa exposes both opaque and ARGB native visuals for otherwise identical RGBA
 // configs. JUCE accepts the first match, so prefer an actual depth-32 X11 visual.
 extern "C" EGLBoolean __wrap_eglChooseConfig(EGLDisplay eglDisplay, const EGLint* attributes, EGLConfig* configs, EGLint configSize, EGLint* configCount) {
-    if (configs == nullptr || configSize <= 0 || !requestsAlpha(attributes)) {
+    if (configs == nullptr || configSize <= 0 || configCount == nullptr || !requestsAlpha(attributes)
+        || getAlphaVisualId().load(std::memory_order_acquire) == 0) {
         return __real_eglChooseConfig(eglDisplay, attributes, configs, configSize, configCount);
     }
 
@@ -286,9 +266,7 @@ extern "C" EGLBoolean __wrap_eglChooseConfig(EGLDisplay eglDisplay, const EGLint
 
     const auto copyCount = juce::jmin(configSize, matchCount);
     std::copy_n(matches.begin(), copyCount, configs);
-    if (configCount != nullptr) {
-        *configCount = copyCount;
-    }
+    *configCount = copyCount;
     return EGL_TRUE;
 }
 
@@ -326,12 +304,11 @@ void TransparentWindow::configureNativeTransparency() {
     const unsigned long forceCompositing = 2;
     XChangeProperty(display, window, bypassCompositor, XA_CARDINAL, 32, PropModeReplace,
                     reinterpret_cast<const unsigned char*>(&forceCompositing), 1);
-    if (transparencyEnabled) {
-        // Mutter promotes an undecorated display-sized window to EWMH fullscreen.
-        // Keep transparent fullscreen as an ordinary composited window instead.
+    if (transparencyEnabled || !fullScreenRequested) {
+        // Mutter can promote a display-sized window to EWMH fullscreen. Clear
+        // that state for transparent mode and when leaving opaque fullscreen.
         setWindowState(display, window, "_NET_WM_STATE_FULLSCREEN", false);
     }
-    setWindowState(display, window, "_NET_WM_STATE_ABOVE", pinned);
     setNativeIgnoresMouseEvents(nativeIgnoresMouseEvents);
 }
 
@@ -354,9 +331,10 @@ bool TransparentWindow::isNativeMouseInteractionStateApplied(bool ignoresMouseEv
     return nativeIgnoresMouseEvents == ignoresMouseEvents;
 }
 
-void TransparentWindow::setNativeAlwaysOnTop(bool alwaysOnTop) {
+void TransparentWindow::applyAlwaysOnTop() {
+    // JUCE's X11 peer cannot change this flag and recreates the peer instead.
     auto* display = getDisplay();
-    setWindowState(display, getWindow(*this), "_NET_WM_STATE_ABOVE", alwaysOnTop);
+    setWindowState(display, getWindow(*this), "_NET_WM_STATE_ABOVE", pinned);
     if (display != nullptr) {
         XFlush(display);
     }
@@ -378,33 +356,31 @@ void TransparentWindow::setNativeRoundedWindowRegion(float radius) {
         return;
     }
     if (radius <= 0.0f) {
-        XFixesSetWindowShapeRegion(display, window, ShapeBounding, 0, 0, None);
+        XShapeCombineMask(display, window, ShapeBounding, 0, 0, None, ShapeSet);
         XFlush(display);
         return;
     }
 
-    XWindowAttributes attributes{};
-    if (XGetWindowAttributes(display, window, &attributes) == False) {
-        return;
-    }
-    const auto scale = getPeer() != nullptr ? static_cast<float>(getPeer()->getPlatformScaleFactor()) : 1.0f;
-    const int scaledRadius = juce::jlimit(1, juce::jmin(attributes.width, attributes.height) / 2,
-                                          juce::roundToInt(radius * scale));
+    // JUCE's resize request may still be queued on its X11 connection. Use the
+    // requested component size rather than querying the previous native size.
+    const auto scale = getDesktopScaleFactor() * (getPeer() != nullptr ? static_cast<float>(getPeer()->getPlatformScaleFactor()) : 1.0f);
+    const int width = juce::jmax(1, juce::roundToInt(getWidth() * scale));
+    const int height = juce::jmax(1, juce::roundToInt(getHeight() * scale));
+    const int scaledRadius = juce::jlimit(0, juce::jmin(width, height) / 2, juce::roundToInt(radius * scale));
     std::vector<XRectangle> rectangles;
     rectangles.reserve(static_cast<std::size_t>(scaledRadius * 2 + 1));
-    rectangles.push_back({ 0, static_cast<short>(scaledRadius), static_cast<unsigned short>(attributes.width),
-                           static_cast<unsigned short>(juce::jmax(0, attributes.height - scaledRadius * 2)) });
+    rectangles.push_back({ 0, static_cast<short>(scaledRadius), static_cast<unsigned short>(width),
+                           static_cast<unsigned short>(juce::jmax(0, height - scaledRadius * 2)) });
     for (int y = 0; y < scaledRadius; ++y) {
         const auto dy = static_cast<double>(scaledRadius - y) - 0.5;
         const int inset = juce::roundToInt(static_cast<double>(scaledRadius)
                                           - std::sqrt(static_cast<double>(scaledRadius * scaledRadius) - dy * dy));
-        const auto width = static_cast<unsigned short>(juce::jmax(0, attributes.width - inset * 2));
-        rectangles.push_back({ static_cast<short>(inset), static_cast<short>(y), width, 1 });
-        rectangles.push_back({ static_cast<short>(inset), static_cast<short>(attributes.height - y - 1), width, 1 });
+        const auto rowWidth = static_cast<unsigned short>(juce::jmax(0, width - inset * 2));
+        rectangles.push_back({ static_cast<short>(inset), static_cast<short>(y), rowWidth, 1 });
+        rectangles.push_back({ static_cast<short>(inset), static_cast<short>(height - y - 1), rowWidth, 1 });
     }
-    const auto region = XFixesCreateRegion(display, rectangles.data(), static_cast<int>(rectangles.size()));
-    XFixesSetWindowShapeRegion(display, window, ShapeBounding, 0, 0, region);
-    XFixesDestroyRegion(display, region);
+    XShapeCombineRectangles(display, window, ShapeBounding, 0, 0, rectangles.data(),
+                            static_cast<int>(rectangles.size()), ShapeSet, Unsorted);
     XFlush(display);
 }
 

--- a/Source/visualiser/TransparentWindow_mac.mm
+++ b/Source/visualiser/TransparentWindow_mac.mm
@@ -51,6 +51,30 @@ juce::Rectangle<int> TransparentWindow::getTransparentFullScreenBounds(juce::Rec
     return display != nullptr ? display->userBounds.toNearestInt() : displayBounds;
 }
 
+void TransparentWindow::removeFullScreenExitObserver() {
+    if (fullScreenExitObserver != nullptr) {
+        [[NSNotificationCenter defaultCenter] removeObserver:static_cast<id>(fullScreenExitObserver)];
+        fullScreenExitObserver = nullptr;
+    }
+}
+
+void TransparentWindow::observeNativeFullScreenExit() {
+    removeFullScreenExitObserver();
+    const juce::Component::SafePointer<TransparentWindow> safeWindow(this);
+    fullScreenExitObserver = [[NSNotificationCenter defaultCenter]
+        addObserverForName:NSWindowDidExitFullScreenNotification object:getWindow(this) queue:nil
+        usingBlock:^(NSNotification*) {
+            // Let JUCE finish its own fullscreen-exit handling before changing bounds.
+            juce::MessageManager::callAsync([safeWindow] {
+                if (safeWindow == nullptr) {
+                    return;
+                }
+                safeWindow->removeFullScreenExitObserver();
+                safeWindow->updatePresentation();
+            });
+        }];
+}
+
 void TransparentWindow::configureNativeTransparency() {
     NSWindow* window = getWindow(this);
     if (window == nil) {

--- a/Source/visualiser/TransparentWindow_mac.mm
+++ b/Source/visualiser/TransparentWindow_mac.mm
@@ -107,6 +107,8 @@ bool TransparentWindow::isNativeMouseInteractionStateApplied(bool ignoresMouseEv
     return !windowIgnoresMouse && acceptsMouseMovedEvents && hasTrackingAreas;
 }
 
+void TransparentWindow::setNativeAlwaysOnTop(bool) {}
+
 void TransparentWindow::setMovesToActiveSpace(bool shouldMove) {
     NSWindow* window = getWindow(this);
     if (window == nil) {

--- a/Source/visualiser/TransparentWindow_mac.mm
+++ b/Source/visualiser/TransparentWindow_mac.mm
@@ -51,6 +51,11 @@ juce::Rectangle<int> TransparentWindow::getTransparentFullScreenBounds(juce::Rec
     return display != nullptr ? display->userBounds.toNearestInt() : displayBounds;
 }
 
+bool TransparentWindow::deferCloseUntilFullScreenExit() {
+    closeAfterFullScreenExit = fullScreenExitObserver != nullptr;
+    return closeAfterFullScreenExit;
+}
+
 void TransparentWindow::removeFullScreenExitObserver() {
     if (fullScreenExitObserver != nullptr) {
         [[NSNotificationCenter defaultCenter] removeObserver:static_cast<id>(fullScreenExitObserver)];
@@ -70,7 +75,13 @@ void TransparentWindow::observeNativeFullScreenExit() {
                     return;
                 }
                 safeWindow->removeFullScreenExitObserver();
-                safeWindow->updatePresentation();
+                if (safeWindow->closeAfterFullScreenExit) {
+                    safeWindow->closeAfterFullScreenExit = false;
+                    safeWindow->reenterFullScreenAfterTransition = false;
+                    safeWindow->closeRequested();
+                } else {
+                    safeWindow->updatePresentation();
+                }
             });
         }];
 }

--- a/Source/visualiser/TransparentWindow_mac.mm
+++ b/Source/visualiser/TransparentWindow_mac.mm
@@ -29,8 +29,8 @@ NSWindow* getWindow(juce::Component* topLevelWindow) {
 }
 
 void removeMouseTrackingAreas(NSView* view) {
-    for (NSTrackingArea* trackingArea in [view trackingAreas]) {
-        [view removeTrackingArea:trackingArea];
+    while ([[view trackingAreas] count] != 0) {
+        [view removeTrackingArea:[[view trackingAreas] objectAtIndex:0]];
     }
 }
 
@@ -45,7 +45,10 @@ bool TransparentWindow::supportsClickThroughInTransparentFullScreen() {
 }
 
 juce::Rectangle<int> TransparentWindow::getTransparentFullScreenBounds(juce::Rectangle<int> displayBounds) {
-    return displayBounds;
+    // AppKit constrains ordinary windows below the menu bar. Fit the usable
+    // desktop so this adjustment cannot push the bottom of the window off-screen.
+    auto* display = juce::Desktop::getInstance().getDisplays().getDisplayForRect(displayBounds);
+    return display != nullptr ? display->userBounds.toNearestInt() : displayBounds;
 }
 
 void TransparentWindow::configureNativeTransparency() {
@@ -59,10 +62,8 @@ void TransparentWindow::configureNativeTransparency() {
     [window setHasShadow:NO];
 
     NSView* contentView = [window contentView];
+    contentView.wantsLayer = YES;
     setViewTreeTransparent(contentView);
-    if (contentView != nil) {
-        contentView.wantsLayer = YES;
-    }
 }
 
 void TransparentWindow::setNativeIgnoresMouseEvents(bool ignoresMouseEvents) {
@@ -106,8 +107,6 @@ bool TransparentWindow::isNativeMouseInteractionStateApplied(bool ignoresMouseEv
     }
     return !windowIgnoresMouse && acceptsMouseMovedEvents && hasTrackingAreas;
 }
-
-void TransparentWindow::setNativeAlwaysOnTop(bool) {}
 
 void TransparentWindow::setMovesToActiveSpace(bool shouldMove) {
     NSWindow* window = getWindow(this);

--- a/Source/visualiser/TransparentWindow_windows.cpp
+++ b/Source/visualiser/TransparentWindow_windows.cpp
@@ -142,6 +142,8 @@ bool TransparentWindow::isNativeMouseInteractionStateApplied(bool ignoresMouseEv
     return ignoresMouseEvents ? ignoresMouse && layered : !ignoresMouse && !layered;
 }
 
+void TransparentWindow::setNativeAlwaysOnTop(bool) {}
+
 void TransparentWindow::setMovesToActiveSpace(bool) {}
 
 void TransparentWindow::setNativeRoundedWindowRegion(float cornerRadius) {

--- a/Source/visualiser/TransparentWindow_windows.cpp
+++ b/Source/visualiser/TransparentWindow_windows.cpp
@@ -142,8 +142,6 @@ bool TransparentWindow::isNativeMouseInteractionStateApplied(bool ignoresMouseEv
     return ignoresMouseEvents ? ignoresMouse && layered : !ignoresMouse && !layered;
 }
 
-void TransparentWindow::setNativeAlwaysOnTop(bool) {}
-
 void TransparentWindow::setMovesToActiveSpace(bool) {}
 
 void TransparentWindow::setNativeRoundedWindowRegion(float cornerRadius) {

--- a/Source/visualiser/VisualiserComponent.cpp
+++ b/Source/visualiser/VisualiserComponent.cpp
@@ -591,7 +591,7 @@ void VisualiserComponent::popoutWindow(bool saveOpenPreference) {
     // Ensure any blocked render completes before changing presentation state.
     renderingSemaphore.release();
 
-#if JUCE_LINUX
+#if JUCE_LINUX || JUCE_MAC
     if (popout != nullptr) {
         popout->showPresentation();
         popoutVisible = true;
@@ -625,6 +625,15 @@ void VisualiserComponent::closePopout() {
         return;
     }
     popout->saveWindowState();
+#if JUCE_MAC
+    // Destroying the peer during AppKit's exit animation leaves its snapshot window behind.
+    if (popout->deferCloseUntilFullScreenExit()) {
+        popoutVisible = false;
+        popoutUpdated();
+        resized();
+        return;
+    }
+#endif
 #if JUCE_LINUX
     popout->suspendPresentation();
     popoutVisible = false;

--- a/Source/visualiser/VisualiserPopout.cpp
+++ b/Source/visualiser/VisualiserPopout.cpp
@@ -32,6 +32,12 @@ void VisualiserPresentationView::paint(juce::Graphics& g) {
     if (!paused) {
         return;
     }
+    auto* window = dynamic_cast<TransparentWindow*>(getTopLevelComponent());
+    if (window != nullptr && !window->isFullScreenRequested()) {
+        juce::Path windowShape;
+        windowShape.addRoundedRectangle(getLocalBounds().toFloat(), TransparentWindow::cornerRadius);
+        g.reduceClipRegion(windowShape);
+    }
     g.setColour(juce::Colours::black.withAlpha(0.5f));
     g.fillRect(getLocalBounds());
     g.setColour(juce::Colours::white);

--- a/Source/visualiser/VisualiserPopout.cpp
+++ b/Source/visualiser/VisualiserPopout.cpp
@@ -20,7 +20,19 @@ VisualiserPresentationView::VisualiserPresentationView(VisualiserComponent& owne
     setCheckerColours(osci::Colours::surface(), osci::Colours::darker());
     const auto themeBase = osci::Colours::surfaceSunken();
     setOpaqueBackground(themeBase.interpolatedWith(osci::Colours::shadow(), osci::Theme::isDark() ? 0.86f : 0.38f));
-    setContextCreatedCallback([](void* context) { TransparentWindow::configureOpenGLSurface(context); });
+    setContextCreatedCallback([this](void* context) {
+        TransparentWindow::configureOpenGLSurface(context);
+#if JUCE_LINUX
+        triggerAsyncUpdate();
+#endif
+    });
+}
+
+void VisualiserPresentationView::handleAsyncUpdate() {
+    auto* window = dynamic_cast<TransparentWindow*>(getTopLevelComponent());
+    if (window != nullptr) {
+        window->refreshPresentationSurface();
+    }
 }
 
 void VisualiserPresentationView::setPaused(bool shouldBePaused) {
@@ -31,12 +43,6 @@ void VisualiserPresentationView::setPaused(bool shouldBePaused) {
 void VisualiserPresentationView::paint(juce::Graphics& g) {
     if (!paused) {
         return;
-    }
-    auto* window = dynamic_cast<TransparentWindow*>(getTopLevelComponent());
-    if (window != nullptr && !window->isFullScreenRequested()) {
-        juce::Path windowShape;
-        windowShape.addRoundedRectangle(getLocalBounds().toFloat(), TransparentWindow::cornerRadius);
-        g.reduceClipRegion(windowShape);
     }
     g.setColour(juce::Colours::black.withAlpha(0.5f));
     g.fillRect(getLocalBounds());

--- a/Source/visualiser/VisualiserPopout.cpp
+++ b/Source/visualiser/VisualiserPopout.cpp
@@ -86,6 +86,9 @@ VisualiserWindow::VisualiserWindow(juce::String name, VisualiserComponent& owner
 }
 
 void VisualiserWindow::showPresentation() {
+#if JUCE_MAC
+    cancelDeferredClose();
+#endif
     setVisible(true);
     setMinimised(false);
     visualiser->setActive(true);

--- a/Source/visualiser/VisualiserPopout.h
+++ b/Source/visualiser/VisualiserPopout.h
@@ -4,7 +4,7 @@
 
 class VisualiserComponent;
 
-class VisualiserPresentationView final : public osci::OpenGLTextureView {
+class VisualiserPresentationView final : private juce::AsyncUpdater, public osci::OpenGLTextureView {
 public:
     explicit VisualiserPresentationView(VisualiserComponent& owner);
 
@@ -15,6 +15,8 @@ public:
     void mouseUp(const juce::MouseEvent& event) override;
 
 private:
+    void handleAsyncUpdate() override;
+
     VisualiserComponent& owner;
     bool paused = false;
     bool pauseOnMouseUp = false;

--- a/osci-render.jucer
+++ b/osci-render.jucer
@@ -649,6 +649,10 @@
               file="Source/visualiser/TransparentWindow_mac.mm"/>
         <FILE id="tW2Win" name="TransparentWindow_windows.cpp" compile="1"
               resource="0" file="Source/visualiser/TransparentWindow_windows.cpp"/>
+        <FILE id="tGlLnx" name="OpenGL_linux.cpp" compile="1" resource="0"
+              file="Source/visualiser/OpenGL_linux.cpp"/>
+        <FILE id="tGlLnh" name="OpenGL_linux.h" compile="0" resource="0"
+              file="Source/visualiser/OpenGL_linux.h"/>
         <FILE id="tW2Lnx" name="TransparentWindow_linux.cpp" compile="1" resource="0"
               file="Source/visualiser/TransparentWindow_linux.cpp"/>
         <FILE id="tW2Oth" name="TransparentWindow_fallback.cpp" compile="1"

--- a/osci-render.jucer
+++ b/osci-render.jucer
@@ -699,7 +699,7 @@
                JUCE_USE_XRENDER="1"/>
   <EXPORTFORMATS>
     <LINUX_MAKE targetFolder="Builds/osci-render/LinuxMakefile" smallIcon="Jk6VkC"
-                bigIcon="Jk6VkC" externalLibraries="luajit&#10;X11&#10;Xfixes&#10;Xext&#10;Xrender"
+                bigIcon="Jk6VkC" externalLibraries="luajit&#10;X11&#10;Xext&#10;Xrender"
                 extraLinkerFlags="-Wl,--wrap=eglChooseConfig">
       <CONFIGURATIONS>
         <CONFIGURATION isDebug="1" name="Debug" targetName="osci-render" headerPath="../../../modules/osci_scripting/third_party/LuaJIT/src&#10;../../../Source/thorvg-config&#10;../../../modules/thorvg/inc&#10;../../../modules/thorvg/src&#10;../../../modules/thorvg/src/common&#10;../../../modules/thorvg/src/renderer&#10;../../../modules/thorvg/src/loaders&#10;../../../modules/thorvg/src/loaders/lottie&#10;../../../modules/thorvg/src/loaders/lottie/rapidjson&#10;../../../modules/thorvg/src/loaders/raw&#10;../../../modules/Clipper2/CPP/Clipper2Lib/include"

--- a/osci-render.jucer
+++ b/osci-render.jucer
@@ -699,7 +699,7 @@
                JUCE_USE_XRENDER="1"/>
   <EXPORTFORMATS>
     <LINUX_MAKE targetFolder="Builds/osci-render/LinuxMakefile" smallIcon="Jk6VkC"
-                bigIcon="Jk6VkC" externalLibraries="luajit&#10;X11&#10;Xfixes&#10;Xext"
+                bigIcon="Jk6VkC" externalLibraries="luajit&#10;X11&#10;Xfixes&#10;Xext&#10;Xrender"
                 extraLinkerFlags="-Wl,--wrap=eglChooseConfig">
       <CONFIGURATIONS>
         <CONFIGURATION isDebug="1" name="Debug" targetName="osci-render" headerPath="../../../modules/osci_scripting/third_party/LuaJIT/src&#10;../../../Source/thorvg-config&#10;../../../modules/thorvg/inc&#10;../../../modules/thorvg/src&#10;../../../modules/thorvg/src/common&#10;../../../modules/thorvg/src/renderer&#10;../../../modules/thorvg/src/loaders&#10;../../../modules/thorvg/src/loaders/lottie&#10;../../../modules/thorvg/src/loaders/lottie/rapidjson&#10;../../../modules/thorvg/src/loaders/raw&#10;../../../modules/Clipper2/CPP/Clipper2Lib/include"

--- a/osci-render.jucer
+++ b/osci-render.jucer
@@ -649,6 +649,8 @@
               file="Source/visualiser/TransparentWindow_mac.mm"/>
         <FILE id="tW2Win" name="TransparentWindow_windows.cpp" compile="1"
               resource="0" file="Source/visualiser/TransparentWindow_windows.cpp"/>
+        <FILE id="tW2Lnx" name="TransparentWindow_linux.cpp" compile="1" resource="0"
+              file="Source/visualiser/TransparentWindow_linux.cpp"/>
         <FILE id="tW2Oth" name="TransparentWindow_fallback.cpp" compile="1"
               resource="0" file="Source/visualiser/TransparentWindow_fallback.cpp"/>
         <FILE id="VTA001" name="VisualiserTextureAssets.h" compile="0" resource="0"
@@ -693,10 +695,12 @@
     </GROUP>
   </MAINGROUP>
   <JUCEOPTIONS JUCE_STRICT_REFCOUNTEDPOINTER="1" JUCE_VST3_CAN_REPLACE_VST2="0"
-               JUCE_WEB_BROWSER="0" JUCE_ASIO="1" JUCE_ENABLE_LIVE_CONSTANT_EDITOR="1"/>
+               JUCE_WEB_BROWSER="0" JUCE_ASIO="1" JUCE_ENABLE_LIVE_CONSTANT_EDITOR="1"
+               JUCE_USE_XRENDER="1"/>
   <EXPORTFORMATS>
     <LINUX_MAKE targetFolder="Builds/osci-render/LinuxMakefile" smallIcon="Jk6VkC"
-                bigIcon="Jk6VkC" externalLibraries="luajit">
+                bigIcon="Jk6VkC" externalLibraries="luajit&#10;X11&#10;Xfixes&#10;Xext"
+                extraLinkerFlags="-Wl,--wrap=eglChooseConfig">
       <CONFIGURATIONS>
         <CONFIGURATION isDebug="1" name="Debug" targetName="osci-render" headerPath="../../../modules/osci_scripting/third_party/LuaJIT/src&#10;../../../Source/thorvg-config&#10;../../../modules/thorvg/inc&#10;../../../modules/thorvg/src&#10;../../../modules/thorvg/src/common&#10;../../../modules/thorvg/src/renderer&#10;../../../modules/thorvg/src/loaders&#10;../../../modules/thorvg/src/loaders/lottie&#10;../../../modules/thorvg/src/loaders/lottie/rapidjson&#10;../../../modules/thorvg/src/loaders/raw&#10;../../../modules/Clipper2/CPP/Clipper2Lib/include"
                        libraryPath="../../../modules/osci_scripting/third_party/LuaJIT/src"/>

--- a/osci-render.jucer
+++ b/osci-render.jucer
@@ -700,7 +700,7 @@
   <EXPORTFORMATS>
     <LINUX_MAKE targetFolder="Builds/osci-render/LinuxMakefile" smallIcon="Jk6VkC"
                 bigIcon="Jk6VkC" externalLibraries="luajit&#10;X11&#10;Xext&#10;Xrender"
-                extraLinkerFlags="-Wl,--wrap=eglChooseConfig">
+                extraLinkerFlags="-Wl,--wrap=eglChooseConfig,--wrap=eglInitialize,--wrap=eglTerminate">
       <CONFIGURATIONS>
         <CONFIGURATION isDebug="1" name="Debug" targetName="osci-render" headerPath="../../../modules/osci_scripting/third_party/LuaJIT/src&#10;../../../Source/thorvg-config&#10;../../../modules/thorvg/inc&#10;../../../modules/thorvg/src&#10;../../../modules/thorvg/src/common&#10;../../../modules/thorvg/src/renderer&#10;../../../modules/thorvg/src/loaders&#10;../../../modules/thorvg/src/loaders/lottie&#10;../../../modules/thorvg/src/loaders/lottie/rapidjson&#10;../../../modules/thorvg/src/loaders/raw&#10;../../../modules/Clipper2/CPP/Clipper2Lib/include"
                        libraryPath="../../../modules/osci_scripting/third_party/LuaJIT/src"/>

--- a/sosci.jucer
+++ b/sosci.jucer
@@ -271,7 +271,7 @@
                JUCE_USE_XRENDER="1"/>
   <EXPORTFORMATS>
     <LINUX_MAKE targetFolder="Builds/sosci/LinuxMakefile" smallIcon="KigaoN"
-                bigIcon="KigaoN" externalLibraries="X11&#10;Xfixes&#10;Xext&#10;Xrender"
+                bigIcon="KigaoN" externalLibraries="X11&#10;Xext&#10;Xrender"
                 extraLinkerFlags="-Wl,--wrap=eglChooseConfig">
       <CONFIGURATIONS>
         <CONFIGURATION isDebug="1" name="Debug" targetName="sosci"/>

--- a/sosci.jucer
+++ b/sosci.jucer
@@ -271,7 +271,7 @@
                JUCE_USE_XRENDER="1"/>
   <EXPORTFORMATS>
     <LINUX_MAKE targetFolder="Builds/sosci/LinuxMakefile" smallIcon="KigaoN"
-                bigIcon="KigaoN" externalLibraries="X11&#10;Xfixes&#10;Xext"
+                bigIcon="KigaoN" externalLibraries="X11&#10;Xfixes&#10;Xext&#10;Xrender"
                 extraLinkerFlags="-Wl,--wrap=eglChooseConfig">
       <CONFIGURATIONS>
         <CONFIGURATION isDebug="1" name="Debug" targetName="sosci"/>

--- a/sosci.jucer
+++ b/sosci.jucer
@@ -243,6 +243,8 @@
               file="Source/visualiser/TransparentWindow_mac.mm"/>
         <FILE id="sW2Win" name="TransparentWindow_windows.cpp" compile="1"
               resource="0" file="Source/visualiser/TransparentWindow_windows.cpp"/>
+        <FILE id="sW2Lnx" name="TransparentWindow_linux.cpp" compile="1" resource="0"
+              file="Source/visualiser/TransparentWindow_linux.cpp"/>
         <FILE id="sW2Oth" name="TransparentWindow_fallback.cpp" compile="1"
               resource="0" file="Source/visualiser/TransparentWindow_fallback.cpp"/>
         <FILE id="VTA002" name="VisualiserTextureAssets.h" compile="0" resource="0"
@@ -265,10 +267,12 @@
     </GROUP>
   </MAINGROUP>
   <JUCEOPTIONS JUCE_STRICT_REFCOUNTEDPOINTER="1" JUCE_VST3_CAN_REPLACE_VST2="0"
-               JUCE_WEB_BROWSER="0" JUCE_USE_MP3AUDIOFORMAT="1" JUCE_ASIO="1"/>
+               JUCE_WEB_BROWSER="0" JUCE_USE_MP3AUDIOFORMAT="1" JUCE_ASIO="1"
+               JUCE_USE_XRENDER="1"/>
   <EXPORTFORMATS>
     <LINUX_MAKE targetFolder="Builds/sosci/LinuxMakefile" smallIcon="KigaoN"
-                bigIcon="KigaoN">
+                bigIcon="KigaoN" externalLibraries="X11&#10;Xfixes&#10;Xext"
+                extraLinkerFlags="-Wl,--wrap=eglChooseConfig">
       <CONFIGURATIONS>
         <CONFIGURATION isDebug="1" name="Debug" targetName="sosci"/>
         <CONFIGURATION isDebug="0" name="Release" targetName="sosci"/>

--- a/sosci.jucer
+++ b/sosci.jucer
@@ -272,7 +272,7 @@
   <EXPORTFORMATS>
     <LINUX_MAKE targetFolder="Builds/sosci/LinuxMakefile" smallIcon="KigaoN"
                 bigIcon="KigaoN" externalLibraries="X11&#10;Xext&#10;Xrender"
-                extraLinkerFlags="-Wl,--wrap=eglChooseConfig">
+                extraLinkerFlags="-Wl,--wrap=eglChooseConfig,--wrap=eglInitialize,--wrap=eglTerminate">
       <CONFIGURATIONS>
         <CONFIGURATION isDebug="1" name="Debug" targetName="sosci"/>
         <CONFIGURATION isDebug="0" name="Release" targetName="sosci"/>

--- a/sosci.jucer
+++ b/sosci.jucer
@@ -243,6 +243,10 @@
               file="Source/visualiser/TransparentWindow_mac.mm"/>
         <FILE id="sW2Win" name="TransparentWindow_windows.cpp" compile="1"
               resource="0" file="Source/visualiser/TransparentWindow_windows.cpp"/>
+        <FILE id="sGlLnx" name="OpenGL_linux.cpp" compile="1" resource="0"
+              file="Source/visualiser/OpenGL_linux.cpp"/>
+        <FILE id="sGlLnh" name="OpenGL_linux.h" compile="0" resource="0"
+              file="Source/visualiser/OpenGL_linux.h"/>
         <FILE id="sW2Lnx" name="TransparentWindow_linux.cpp" compile="1" resource="0"
               file="Source/visualiser/TransparentWindow_linux.cpp"/>
         <FILE id="sW2Oth" name="TransparentWindow_fallback.cpp" compile="1"

--- a/tests/PopoutInteractionTests.cpp
+++ b/tests/PopoutInteractionTests.cpp
@@ -115,6 +115,18 @@ public:
         const auto limited = deriveTransparentWindowInteractionPolicy(context);
         expect(capable.mode == TransparentWindowInteractionMode::alphaAware);
         expect(limited.mode == TransparentWindowInteractionMode::interactive);
+
+        beginTest("Unavailable fullscreen pass-through preserves requested controls");
+        context.frameRequestedVisible = true;
+        context.passThroughRequested = true;
+        const auto unavailable = deriveTransparentWindowInteractionPolicy(context);
+        expect(unavailable.frameVisible);
+        expect(unavailable.mode == TransparentWindowInteractionMode::interactive);
+        expect(context.passThroughRequested);
+        context.alphaClickThroughAllowed = true;
+        const auto restored = deriveTransparentWindowInteractionPolicy(context);
+        expect(!restored.frameVisible);
+        expect(restored.mode == TransparentWindowInteractionMode::passAll);
     }
 };
 


### PR DESCRIPTION
Adds transparent visualiser popouts on Linux with compositor and EGL visual checks, native click-through, rounded corners, pinning, and fullscreen transitions. Systems without the required support retain an opaque native window.

Fixes Linux fullscreen state remaining active after exit and rounded regions using stale dimensions during resize. Keeps the shared EGL display alive until the last context releases it: JUCE otherwise terminates the editor's graphics display when opening an overlay hides the visualiser, leaving settings/About invisible or the editor frozen. Simplifies shared presentation handling and removes the XFixes dependency.

## Other platforms

- macOS: native fullscreen-exit notifications replace the fixed transition delay. Closing during native fullscreen exit waits for completion before destroying the peer, preventing AppKit snapshot windows being left behind; reopening cancels that deferred close. Transparent fullscreen uses the usable desktop. Native transparency and mouse tracking cleanup is tightened.
- Windows: shared interaction policy preserves requested controls when fullscreen click-through is unavailable. Removes an unused native pinning method. The remaining 250 ms fullscreen settling workaround is confined to Linux.

## Validation

- Visualiser unit tests passed, including unavailable fullscreen click-through coverage.
- Both macOS standalone Debug builds passed. A seeded 36-scenario fuzz run passed native window-count and bounds checks, with desktop captures inspected. Focused tests reproduced and verified the fix for the fullscreen-exit duplicate-window regression.
- Linux sosci Debug and Release standalone builds passed; the EGL lifetime follow-up was rebuilt and tested in Debug.
- Ubuntu Xorg/Mutter: live transparent rendering, native click-through, fullscreen conversions, bounds restoration, pinning, repeated reopening, and rounded resizing checked. Opaque fallback checked without a compositor.
- An isolated EGL lifecycle check reproduced context destruction after another owner releases the display; the production wrappers preserve the context until the final release.
- Linux overlay follow-up: repeated Audio/MIDI Settings, Recording Settings, and About open/close checks, including with a transparent popout, with direct VM screen captures inspected.
- Windows runtime was not tested. The general macOS browser smoke run hit feedback-dialog automation failures; focused transparency checks passed.
