### PR TITLE
Speed up OBJ loading and reduce graph memory use

### DIFF
--- a/osci-render-test.jucer
+++ b/osci-render-test.jucer
@@ -156,6 +156,8 @@
             file="tests/RecordingExporterTests.cpp"/>
       <FILE id="VisTexT" name="VisualiserTextureOutputControllerTests.cpp"
             compile="1" resource="0" file="tests/VisualiserTextureOutputControllerTests.cpp"/>
+      <FILE id="ObjTst" name="ObjLoadingTests.cpp" compile="1" resource="0"
+            file="tests/ObjLoadingTests.cpp"/>
       <FILE id="LotTst" name="LottieParserTests.cpp" compile="1" resource="0"
             file="tests/LottieParserTests.cpp"/>
       <FILE id="UndoRedo" name="UndoRedoTests.cpp" compile="1" resource="0"
@@ -210,6 +212,7 @@
     <MODULE id="juce_mts_esp" showAllCode="1" useLocalCopy="0" useGlobalPath="0"/>
     <MODULE id="juce_opengl" showAllCode="1" useLocalCopy="0" useGlobalPath="1"/>
     <MODULE id="melatonin_blur" showAllCode="1" useLocalCopy="0" useGlobalPath="0"/>
+    <MODULE id="osci_file_import" showAllCode="1" useLocalCopy="0" useGlobalPath="0"/>
     <MODULE id="osci_gui" showAllCode="1" useLocalCopy="0" useGlobalPath="0"/>
     <MODULE id="osci_licensing" showAllCode="1" useLocalCopy="0" useGlobalPath="0"/>
     <MODULE id="osci_render_core" showAllCode="1" useLocalCopy="0" useGlobalPath="0"/>
@@ -246,6 +249,7 @@
         <MODULEPATH id="juce_dsp" path="../JUCE/modules"/>
         <MODULEPATH id="juce_audio_formats" path="../JUCE/modules"/>
         <MODULEPATH id="juce_audio_processors_headless" path="../JUCE/modules"/>
+        <MODULEPATH id="osci_file_import" path="modules"/>
         <MODULEPATH id="osci_gui" path="modules"/>
         <MODULEPATH id="juce_audio_utils" path="../JUCE/modules"/>
         <MODULEPATH id="juce_audio_devices" path="../JUCE/modules"/>
@@ -280,6 +284,7 @@
         <MODULEPATH id="juce_dsp" path="../JUCE/modules"/>
         <MODULEPATH id="juce_audio_formats" path="../JUCE/modules"/>
         <MODULEPATH id="juce_audio_processors_headless" path="../JUCE/modules"/>
+        <MODULEPATH id="osci_file_import" path="modules"/>
         <MODULEPATH id="osci_gui" path="modules"/>
         <MODULEPATH id="juce_audio_utils" path="../JUCE/modules"/>
         <MODULEPATH id="juce_audio_devices" path="../JUCE/modules"/>
@@ -313,6 +318,7 @@
         <MODULEPATH id="juce_dsp" path="../JUCE/modules"/>
         <MODULEPATH id="juce_audio_formats" path="../JUCE/modules"/>
         <MODULEPATH id="juce_audio_processors_headless" path="../JUCE/modules"/>
+        <MODULEPATH id="osci_file_import" path="modules"/>
         <MODULEPATH id="osci_gui" path="modules"/>
         <MODULEPATH id="juce_audio_utils" path="../JUCE/modules"/>
         <MODULEPATH id="juce_audio_devices" path="../JUCE/modules"/>

--- a/tests/ObjLoadingTests.cpp
+++ b/tests/ObjLoadingTests.cpp
@@ -1,0 +1,72 @@
+#include <juce_core/juce_core.h>
+#include <osci_file_import/osci_file_import.h>
+#include "../modules/osci_file_import/third_party/chinese_postman/Graph.h"
+#include "../modules/osci_file_import/third_party/chinese_postman/ParallelWork.h"
+
+class ObjLoadingTests final : public juce::UnitTest {
+public:
+    ObjLoadingTests() : juce::UnitTest("OBJ loading", "OBJ") {}
+
+    void runTest() override {
+        beginTest("Large sparse graphs count undirected edges once without index overflow");
+        std::list<std::pair<int, int>> edges{{0, 49999}, {49999, 0}, {49998, 49999}};
+        Graph sparse(50000, edges);
+        expectEquals(sparse.GetNumEdges(), 2);
+        expectEquals(sparse.GetEdgeIndex(0, 49999), sparse.GetEdgeIndex(49999, 0));
+        expect(sparse.GetEdge(0) == std::make_pair(0, 49999));
+        expect(sparse.IsAdjacent(49999, 49998));
+        expect(!sparse.IsAdjacent(0, 49998));
+
+        beginTest("Complete graph lookup agrees with stored edges in both directions");
+        Graph complete(10);
+        expectEquals(complete.GetNumEdges(), 45);
+        for (int i = 0; i < complete.GetNumEdges(); ++i) {
+            const auto [u, v] = complete.GetEdge(i);
+            expectEquals(complete.GetEdgeIndex(u, v), i);
+            expectEquals(complete.GetEdgeIndex(v, u), i);
+        }
+
+        beginTest("Reusing a graph preserves reconstructed adjacency order");
+        std::list<std::pair<int, int>> input{{0, 1}, {0, 2}, {1, 2}, {2, 3}};
+        Graph reused(4, input);
+        const std::vector<int> visitOrder{0, 2, 3, 1};
+        std::list<std::pair<int, int>> rebuiltEdges;
+        for (int u : visitOrder) {
+            for (int v : reused.AdjList(u)) { rebuiltEdges.emplace_back(u, v); }
+        }
+        Graph rebuilt(4, rebuiltEdges);
+        reused.OrderAdjacency(visitOrder);
+        for (int u = 0; u < 4; ++u) { expect(reused.AdjList(u) == rebuilt.AdjList(u)); }
+
+        beginTest("A single OBJ edge produces a finite closed out-and-back route");
+        WorldObject object("v 0 0 0\nv 1 0 0\nl 1 2\n");
+        expectEquals(int(object.edges.size()), 2);
+        if (object.edges.size() == 2) {
+            const auto& a = object.edges[0];
+            const auto& b = object.edges[1];
+            expect(std::isfinite(a.x1) && std::isfinite(a.x2));
+            expect(a.x1 == b.x2 && a.x2 == b.x1 && a.x1 != a.x2);
+        }
+
+        beginTest("Nested work runs every job exactly once and remains usable after exceptions");
+        ParallelWork work(4);
+        std::vector<std::atomic<int>> hits(128);
+        for (auto& hit : hits) { hit.store(0); }
+        work.forEach(8, [&](size_t outer) {
+            work.forEach(16, [&](size_t inner) { ++hits[outer * 16 + inner]; });
+        });
+        for (auto& hit : hits) { expectEquals(hit.load(), 1); }
+        bool caught = false;
+        try {
+            work.forEach(16, [](size_t i) {
+                if (i == 0) { throw std::runtime_error("expected"); }
+            });
+        } catch (const std::runtime_error&) { caught = true; }
+        expect(caught);
+        std::atomic<int> count{0};
+        work.forEach(16, [&](size_t) { ++count; });
+        expectEquals(count.load(), 16);
+    }
+};
+
+static ObjLoadingTests objLoadingTests;


### PR DESCRIPTION
Speeds up OBJ loading and reduces graph memory use while preserving the generated route.

- Replace quadratic adjacency storage with sparse edge lookup and fix overflowing vertex-index arithmetic and duplicate edge counting.
- Prepare edge weights once, simplify heap decreases, and reuse the graph for connected objects while preserving traversal order.
- Share a worker budget between shortest-path searches and substantial disconnected components. Use physical core count, capped at 16; leave cheap workloads serial. Matching stays serial.

On an M3 Pro, the selected implementation loaded 31,658-vertex Suzanne in **146 ms**, a 40,000-vertex grid in **457 ms**, and 25 lamp copies in **156 ms**. Earlier original-code measurements were 1.09 s and 3.62 s for Suzanne and the grid; the large lamp input crashed from index overflow. These are constructor timings from separate local runs, not end-to-end UI latency. Parallelism can increase aggregate CPU work.

The first sparse-graph comparison reduced peak memory for the large grid from approximately **619 MiB to 207 MiB**.

Implementation diffs:
- [File import](https://github.com/jameshball/osci_file_import/compare/e192061...6d52625)
- [Graph solver](https://github.com/jameshball/chinese-postman/compare/2c4d971...625671b)

Validation: local compilation and the regular test suite passed. Focused checks covered 144 loads across 48 models with identical ordered routes, 80 small graphs checked against independent shortest-path/minimum-pairing calculations, 7 ThreadSanitizer cases, and 90 AddressSanitizer/UBSan cases.

Adds five small regression checks to the regular suite: sparse indexing/duplicate edges, complete-graph indices, adjacency order when reusing a graph, a closed OBJ route, and nested worker execution/exception recovery. The large profiling harness remains untracked. Sanitizers covered the copied loader/solver, not the linked geometry library. No UI or Windows/Linux runtime tests were run.
