### PR TITLE
Fix popup menu look and feel inheritance

### DIFF
--- a/Source/components/modulation/LfoComponent.cpp
+++ b/Source/components/modulation/LfoComponent.cpp
@@ -746,6 +746,7 @@ void LfoComponent::showPaintShapeMenu() {
     addItem("Tri", PS::Tri);
     addItem("Bump", PS::Bump);
 
+    menu.setLookAndFeel(&getLookAndFeel());
     menu.showMenuAsync(juce::PopupMenu::Options()
         .withTargetComponent(&shapePreview)
         .withMinimumWidth(80));

--- a/Source/components/modulation/LfoPresetBrowserOverlay.cpp
+++ b/Source/components/modulation/LfoPresetBrowserOverlay.cpp
@@ -136,6 +136,7 @@ void LfoPresetBrowserOverlay::PresetRow::mouseDown(const juce::MouseEvent& e) {
         } else {
             menu.addItem("Set as Default", [this]() { if (onSetDefault) onSetDefault(); });
         }
+        menu.setLookAndFeel(&getLookAndFeel());
         menu.showMenuAsync(juce::PopupMenu::Options().withTargetScreenArea(
             { e.getScreenX(), e.getScreenY(), 1, 1 }));
     }

--- a/Source/components/modulation/ModulationModeComponent.cpp
+++ b/Source/components/modulation/ModulationModeComponent.cpp
@@ -60,6 +60,7 @@ void ModulationModeComponent::showModePopup() {
         menu.addItem(value + 1, name, true, value == mode);
     }
 
+    menu.setLookAndFeel(&getLookAndFeel());
     menu.showMenuAsync(juce::PopupMenu::Options().withTargetComponent(this),
         [this](int result) {
             if (result > 0)

--- a/Source/components/modulation/ModulationRateComponent.cpp
+++ b/Source/components/modulation/ModulationRateComponent.cpp
@@ -231,6 +231,7 @@ void ModulationRateComponent::showModePopup() {
     menu.addItem(3, "Tempo Dotted",    true, rateMode == LfoRateMode::TempoDotted);
     menu.addItem(4, "Tempo Triplets",  true, rateMode == LfoRateMode::TempoTriplets);
 
+    menu.setLookAndFeel(&getLookAndFeel());
     menu.showMenuAsync(juce::PopupMenu::Options().withTargetComponent(this),
         [this](int result) {
             if (result == 0) return;

--- a/Source/components/modulation/ModulationSourceComponent.cpp
+++ b/Source/components/modulation/ModulationSourceComponent.cpp
@@ -163,6 +163,7 @@ void ModulationSourceComponent::DepthIndicator::showRightClickMenu() {
 #endif
 
     juce::Component::SafePointer<DepthIndicator> safeThis(this);
+    menu.setLookAndFeel(&getLookAndFeel());
     menu.showMenuAsync(juce::PopupMenu::Options().withTargetComponent(this),
         [safeThis
 #if OSCI_PREMIUM


### PR DESCRIPTION
Detached popup menus were falling back to JUCE’s default grey theme after the shared LookAndFeel stopped changing the global default. This updates `osci_gui` to attach right-click menus to their owner’s LookAndFeel and applies the same explicit ownership to osci-render’s modulation popup call sites.

Before: right-clicking a parameter showed a square grey JUCE menu.

After: the same menu uses the plugin’s near-black rounded panel, border, separators, font, and highlight styling.

Validation: macOS arm64 Debug standalone build passed; the exact parameter context menu was opened and captured with Jucewright after rebuilding.

Depends on jameshball/osci_gui#10.
